### PR TITLE
libdlt: Avoid busy loop in error case of mq_receive()

### DIFF
--- a/src/lib/dlt_user_cfg.h
+++ b/src/lib/dlt_user_cfg.h
@@ -140,6 +140,9 @@
 /* Sleeps between resending user buffer at exit in usec (1000 usec = 1ms)*/
 #define DLT_USER_ATEXIT_RESEND_BUFFER_SLEEP 100000
 
+/* Retry interval for mq error in usec */
+#define DLT_USER_MQ_ERROR_RETRY_INTERVAL 100000
+
 
 /************************/
 /* Don't change please! */


### PR DESCRIPTION
To avoid busy loop due to error of mq_receive() which is called
in sub thread, 100ms sleep is added for the error case.
Error log message for mq_receive() is also corrected to have errno.

Signed-off-by: Yusuke Sato <yusuke-sato@apn.alpine.co.jp>