### PR TITLE
dlt_daemon_client.c Adding NULL check for tok

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #######
 
 cmake_minimum_required(VERSION 3.3)
-project(automotive-dlt VERSION 2.18.4)
+project(automotive-dlt VERSION 2.18.5)
 
 mark_as_advanced(CMAKE_BACKWARDS_COMPATIBILITY)
 set(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,9 +4,131 @@ Back to [README.md](../README.md)
 
 ## Version
 
-2.18.4 STABLE
+2.18.5 STABLE
 
 ## Changes
+
+### 2.18.5
+
+   * Update releaseNotes and version to v2.18.5
+   * slog2 adapter on QNX
+   * Update gtest_dlt_all.sh to detect core dump
+   * dlt-daemon.c: fix printf format %d to %ld that formats a long
+   * doc/CMakeList.txt: replace dlt_design_specification.txt to .md
+   * network trace: Fix macro usage
+   * limit logspam in gateway on client overflow
+   * Android.bp: fix dlt_user.h genrule
+   * logstorage: Issue with more than 2 filters
+   * remove unused feature
+   * gtest_dlt_daemon_gateway: correct comparison operator syntax
+   * set DLT_NETWORK_TRACE_ENABLE by cmakedefine
+   * doc: Update dlt_offline_logstorage.md
+   * UT: Fix segfault in logstorage test
+   * logstorage: support all stragegies
+   * update cmake VERSION variables
+   * simplify and fix android version script
+   * execute unittests with cmake
+   * dlt_design_specification: update content
+   * dlt_design_specification: convert from .txt to .md format
+   * logstorage: fix syncbehaviour
+   * daemon: Fix smoketest
+   * unittest: Update according to API's changes
+   * offline storage: Improvement log messages at bottom
+   * common: Isolate FIFO/Unix socket
+   * libdlt: Relocate dltFifoBaseDir setting
+   * doc: md file for dlt_gateway.conf
+   * network trace: Include necessary headers
+   * network trace: Add mqueue verification
+   * Unittest for new api
+   * Remove duplicate definition of DLT_CONVERT_TEXTBUFSIZE
+   * Improve performance of DLT file parsing
+   * relocation dlt_check_envvar() and update dlt_init() functions
+   * Redirect stdout to stderr
+   * Unittest: Update testcase
+   * gateway: Improvement of handling Gateway config
+   * daemon: Avoid spamming message buffer overflow
+   * gateway: Support infinite loop of retry
+   * gateway: Configurable interval time
+   * tests: remove unused zlib include
+   * disable android services by default
+   * logstorage: Add NULL check of IDs
+   * snprintf ret > 0 is not always an error
+   * fix some gcc9 compiler warnings
+   * fix clang warnings about GNU stuff
+   * android logd forwarder
+   * fix gateway config element search
+   * doc: update a note for logstorage with wildcard
+   * daemon: logstorage with wildcards
+   * Limit log messages on full buffer
+   * Android: Enable Android build
+   * logstorage: Filter section handling
+   * doc: Logstorage non-verbose filter
+   * correct errno usage in dlt_stop_threads
+   * shared: Read DLT header until it's found
+   * Use ssize_t for bytes_written
+   * Fix dlt-sortbytimestamp
+   * Remove DLT_PACKED redefinition guard in dlt_common.h
+   * rename definition PACKED to DLT_PACKED
+   * daemon: Remove empty line in daemon log
+   * Revert "dlt_common: Fix buffer overflow in dlt_buffer_get (#215)"
+   * FIX: prevent usage of uninitialized message queue handle
+   * Add unit tests for new sized string functions
+   * Add documentation for new sized string functions
+   * Add macro wrappers for new sized string functions
+   * Minor optimization
+   * Add functions for writing strings with known sizes
+   * Add helper function for writing strings with known sizes
+   * Fixed empty internal message in dlt-daemon.c (#225)
+   * common: Fix uint64 type (#217)
+   * dlt_common: Fix buffer overflow in dlt_buffer_get (#215)
+   * FIX: Check validity of `file` pointer before usage.
+   * doc/dlt_for_developers.md: Fix wrong DLT include directive
+   * Remove naming of variadic macro parameters
+   * sys/poll.h: deprecate old sys/poll.h include header, now glibc/musl wants poll.h being included directly. This fixes a build failure on musl systems with strict c hardening flags
+   * dlt-test-init-free: fix build failure with strict compiler flags, due to uint being undefined. This is actually an "int" type, looking at the test implementation
+   * dlt_user.h: fix build when musl is the libc implementation, by adding a missing include for pthread_t reference:
+   * dlt.conf: suppress the warnings udp multicast (#197)
+   * dlt_daemon_socket: leave while socket binds fails
+   * dlt_user: init DltContextData before use
+   * dlt-daemon: fix resource leak
+   * console: fix memleak of dlt-logstorage-list
+   * BugFix: SEGFAULT when using AppArmor (#192)
+   * Fix compiler warnings: pointer of type ‘void *’ used in arithmetic (#196)
+   * Change the DLT_CHECK_RCV_DATA_SIZE macro to an internal function (#191)
+   * Fix a potential memory leak in file transfer (#126)
+   * Provide DLT_GET_APPID macro (#187) (#188)
+   * dlt-offline-trace: fix bug and hardcode (#174) (#186)
+   * Avoided Seg fault in dlt_message_payload (#179) (#181)
+   * Improvement: Make ZLib dependency optional (#182)
+   * fix the dlt offline trace file name creation (#178)
+   * libdlt: fix memory leak
+   * Removed unused headers(epoll) in UDP connection
+   * Fix: Propper usage of LoggingMode: "uncrustification"
+   * Fix: Propper usage of LoggingMode in ".../dlt-runtime.cfg"
+   * libdlt: reattachment and improvement in dlt thread (#171)
+   * dlt-system: Call tzset before localtime_r (#165)
+   * Update cmakelist, fix build due to copy-paste error (#170)
+   * Bugfix: dlt-system-journal
+   * Proper setup and error checking of pthread_create
+   * udp: Disable WITH_UDP_CONNECTION as default
+   * doxygen improvement
+   * doc: Modify markdown doc generation
+   * doc: Update dlt_for_developers.md
+   * cmake improvement for Logstorage console
+   * cmake add component for libdlt.so
+   * parser: Change maximum number of config section
+   * common: Remove unused structure
+   * dlt_common: Use defined macro
+   * libdlt: calculate resend buffer memory
+   * lib: Disable extended header in non verbose mode by env var
+   * shm: Resend dlt msg when client connect
+   * lib: Remove else nothing
+   * network trace: Do not allow DLT usage in forked child
+   * lib: Assign fd after it's closed
+   * console: Add get sw version control msg
+   * console: Tool to merge multiple DLT files
+   * dlt-test: Add message length option
+   * Add user custom timestamp interface
 
 ### 2.18.4
 

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1800,6 +1800,8 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
 
         if (dlt_daemon_send_ringbuffer_to_client(daemon, daemon_local, verbose) == -1) {
             dlt_log(LOG_WARNING, "Can't send contents of ringbuffer to clients\n");
+			close(in_sock);
+			in_sock = -1;
             return -1;
         }
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1083,7 +1083,7 @@ void dlt_daemon_control_get_log_info(int sock,
                                                       daemon->ecuid,
                                                       verbose);
 
-            if (application) {
+            if ((user_list->applications) && (application)) {
                 /* Calculate start offset within contexts[] */
                 offset_base = 0;
 

--- a/src/daemon/dlt_daemon_offline_logstorage.c
+++ b/src/daemon/dlt_daemon_offline_logstorage.c
@@ -232,9 +232,14 @@ DLT_STATIC DltReturnValue dlt_logstorage_split_multi(char *key,
     else {
         strncpy(ecuid, tok, DLT_ID_SIZE);
         tok = strtok(NULL, ":");
-        strncpy(apid, tok, DLT_ID_SIZE);
-        tok = strtok(NULL, ":");
-        strncpy(ctid, tok, DLT_ID_SIZE);
+		
+		if (tok != NULL)
+        	strncpy(apid, tok, DLT_ID_SIZE);
+		
+		tok = strtok(NULL, ":");
+		
+		if (tok != NULL)
+			strncpy(ctid, tok, DLT_ID_SIZE);
     }
 
     return DLT_RETURN_OK;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1571,33 +1571,40 @@ DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
         return DLT_RETURN_ERROR;
 
     /* initialize values */
-    if (log->buffer == NULL) {
+     if ((NULL != log->buffer))
+     {
+       free(log->buffer);
+       log->buffer = NULL;
+     }
+     else 
+     {
         log->buffer = calloc(sizeof(unsigned char), dlt_user.log_buf_len);
-
-        if (log->buffer == NULL) {
+	 }
+	 	
+     if (log->buffer == NULL) {
             dlt_vlog(LOG_ERR, "Cannot allocate buffer for DLT Log message\n");
             return DLT_RETURN_ERROR;
-        }
-    }
+     }
+    else {
 
-    log->args_num = 0;
-    log->log_level = loglevel;
-    log->size = 0;
-    log->use_timestamp = DLT_AUTO_TIMESTAMP;
+    	log->args_num = 0;
+    	log->log_level = loglevel;
+    	log->size = 0;
+    	log->use_timestamp = DLT_AUTO_TIMESTAMP;
 
-    /* In non-verbose mode, insert message id */
-    if (dlt_user.verbose_mode == 0) {
-        if ((sizeof(uint32_t)) > dlt_user.log_buf_len)
-            return DLT_RETURN_USER_BUFFER_FULL;
+    	/* In non-verbose mode, insert message id */
+    	if (dlt_user.verbose_mode == 0) {
+        	if ((sizeof(uint32_t)) > dlt_user.log_buf_len)
+            	return DLT_RETURN_USER_BUFFER_FULL;
 
-        /* Write message id */
-        memcpy(log->buffer, &(messageid), sizeof(uint32_t));
-        log->size = sizeof(uint32_t);
+        	/* Write message id */
+        	memcpy(log->buffer, &(messageid), sizeof(uint32_t));
+        	log->size = sizeof(uint32_t);
 
-        /* as the message id is part of each message in non-verbose mode,
-         * it doesn't increment the argument counter in extended header (if used) */
-    }
-
+        	/* as the message id is part of each message in non-verbose mode,
+         	* it doesn't increment the argument counter in extended header (if used) */
+		}
+	}
     return DLT_RETURN_TRUE;
 }
 

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -397,7 +397,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
     while (!feof(handle)) {
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%255s", str1) != 1)
             break;
 
         if (str1[0] == 0)
@@ -412,7 +412,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
 
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%255s", str1) != 1)
             break;
 
         if (str1[0] == 0)
@@ -1732,7 +1732,7 @@ void dlt_log_set_filename(const char *filename)
 #ifndef DLT_USE_UNIX_SOCKET_IPC
 void dlt_log_set_fifo_basedir(const char *pipe_dir)
 {
-    strncpy(dltFifoBaseDir, pipe_dir, DLT_PATH_MAX);
+    strncpy(dltFifoBaseDir, pipe_dir, DLT_PATH_MAX-1);
     dltFifoBaseDir[DLT_PATH_MAX - 1] = 0;
 }
 #endif

--- a/src/shared/dlt_config_file_parser.c
+++ b/src/shared/dlt_config_file_parser.c
@@ -494,8 +494,8 @@ int dlt_config_file_get_section_name(const DltConfigFile *file,
     if ((file == NULL) || (name == NULL) || (num < 0) || (num >= file->num_sections))
         return -1;
 
-    strncpy(name, (file->sections + num)->name, DLT_CONFIG_FILE_ENTRY_MAX_LEN);
-
+    strncpy(name, (file->sections + num)->name, DLT_CONFIG_FILE_ENTRY_MAX_LEN-1);
+	name[strlen((file->sections + num)->name)-1]='\0';
     return 0;
 }
 

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -295,6 +295,9 @@ int dlt_offline_trace_delete_oldest_file(DltOfflineTrace *trace)
 
     /* go through all dlt files in directory */
     DIR *dir = opendir(trace->directory);
+	
+	if(!dir)
+		return -1;
 
     while ((dp = readdir(dir)) != NULL)
         if (strstr(dp->d_name, DLT_OFFLINETRACE_FILENAME_BASE)) {


### PR DESCRIPTION
dlt_daemon_offline_logstorage.c : Adding NULL check for application
dlt_daemon_common.c : fix printf format %d to %ld that formats a long
dlt_common.c: fix printf format %d to %ld that formats a long
dlt_user.c : Fix for Memory Leak
dlt-daemon.c : Fix for Resource Leak
dlt_offline_trace.c : Fix for Resource Leak

Signed-off-by: Mvaradaraj2 <manoj.varadaraj2@harman.com>