### PR TITLE
Summary : Fix for Resource and Memory Leak

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1800,6 +1800,8 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
 
         if (dlt_daemon_send_ringbuffer_to_client(daemon, daemon_local, verbose) == -1) {
             dlt_log(LOG_WARNING, "Can't send contents of ringbuffer to clients\n");
+			close(in_sock);
+			in_sock = -1;
             return -1;
         }
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1083,7 +1083,7 @@ void dlt_daemon_control_get_log_info(int sock,
                                                       daemon->ecuid,
                                                       verbose);
 
-            if (application) {
+            if ((user_list->applications) && (application)) {
                 /* Calculate start offset within contexts[] */
                 offset_base = 0;
 

--- a/src/daemon/dlt_daemon_offline_logstorage.c
+++ b/src/daemon/dlt_daemon_offline_logstorage.c
@@ -232,9 +232,14 @@ DLT_STATIC DltReturnValue dlt_logstorage_split_multi(char *key,
     else {
         strncpy(ecuid, tok, DLT_ID_SIZE);
         tok = strtok(NULL, ":");
-        strncpy(apid, tok, DLT_ID_SIZE);
-        tok = strtok(NULL, ":");
-        strncpy(ctid, tok, DLT_ID_SIZE);
+		
+		if (tok != NULL)
+        	strncpy(apid, tok, DLT_ID_SIZE);
+		
+		tok = strtok(NULL, ":");
+		
+		if (tok != NULL)
+			strncpy(ctid, tok, DLT_ID_SIZE);
     }
 
     return DLT_RETURN_OK;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1571,33 +1571,40 @@ DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
         return DLT_RETURN_ERROR;
 
     /* initialize values */
-    if (log->buffer == NULL) {
+     if ((NULL != log->buffer))
+     {
+       free(log->buffer);
+       log->buffer = NULL;
+     }
+     else 
+     {
         log->buffer = calloc(sizeof(unsigned char), dlt_user.log_buf_len);
-
-        if (log->buffer == NULL) {
+	 }
+	 	
+     if (log->buffer == NULL) {
             dlt_vlog(LOG_ERR, "Cannot allocate buffer for DLT Log message\n");
             return DLT_RETURN_ERROR;
-        }
-    }
+     }
+    else {
 
-    log->args_num = 0;
-    log->log_level = loglevel;
-    log->size = 0;
-    log->use_timestamp = DLT_AUTO_TIMESTAMP;
+    	log->args_num = 0;
+    	log->log_level = loglevel;
+    	log->size = 0;
+    	log->use_timestamp = DLT_AUTO_TIMESTAMP;
 
-    /* In non-verbose mode, insert message id */
-    if (dlt_user.verbose_mode == 0) {
-        if ((sizeof(uint32_t)) > dlt_user.log_buf_len)
-            return DLT_RETURN_USER_BUFFER_FULL;
+    	/* In non-verbose mode, insert message id */
+    	if (dlt_user.verbose_mode == 0) {
+        	if ((sizeof(uint32_t)) > dlt_user.log_buf_len)
+            	return DLT_RETURN_USER_BUFFER_FULL;
 
-        /* Write message id */
-        memcpy(log->buffer, &(messageid), sizeof(uint32_t));
-        log->size = sizeof(uint32_t);
+        	/* Write message id */
+        	memcpy(log->buffer, &(messageid), sizeof(uint32_t));
+        	log->size = sizeof(uint32_t);
 
-        /* as the message id is part of each message in non-verbose mode,
-         * it doesn't increment the argument counter in extended header (if used) */
-    }
-
+        	/* as the message id is part of each message in non-verbose mode,
+         	* it doesn't increment the argument counter in extended header (if used) */
+		}
+	}
     return DLT_RETURN_TRUE;
 }
 

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -397,7 +397,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
     while (!feof(handle)) {
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%255s", str1) != 1)
             break;
 
         if (str1[0] == 0)
@@ -412,7 +412,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
 
         str1[0] = 0;
 
-        if (fscanf(handle, "%s", str1) != 1)
+        if (fscanf(handle, "%255s", str1) != 1)
             break;
 
         if (str1[0] == 0)
@@ -1732,7 +1732,7 @@ void dlt_log_set_filename(const char *filename)
 #ifndef DLT_USE_UNIX_SOCKET_IPC
 void dlt_log_set_fifo_basedir(const char *pipe_dir)
 {
-    strncpy(dltFifoBaseDir, pipe_dir, DLT_PATH_MAX);
+    strncpy(dltFifoBaseDir, pipe_dir, DLT_PATH_MAX-1);
     dltFifoBaseDir[DLT_PATH_MAX - 1] = 0;
 }
 #endif

--- a/src/shared/dlt_config_file_parser.c
+++ b/src/shared/dlt_config_file_parser.c
@@ -494,8 +494,8 @@ int dlt_config_file_get_section_name(const DltConfigFile *file,
     if ((file == NULL) || (name == NULL) || (num < 0) || (num >= file->num_sections))
         return -1;
 
-    strncpy(name, (file->sections + num)->name, DLT_CONFIG_FILE_ENTRY_MAX_LEN);
-
+    strncpy(name, (file->sections + num)->name, DLT_CONFIG_FILE_ENTRY_MAX_LEN-1);
+	name[strlen((file->sections + num)->name)-1]='\0';
     return 0;
 }
 

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -295,6 +295,9 @@ int dlt_offline_trace_delete_oldest_file(DltOfflineTrace *trace)
 
     /* go through all dlt files in directory */
     DIR *dir = opendir(trace->directory);
+	
+	if(!dir)
+		return -1;
 
     while ((dp = readdir(dir)) != NULL)
         if (strstr(dp->d_name, DLT_OFFLINETRACE_FILENAME_BASE)) {


### PR DESCRIPTION
dlt_daemon_client.c Adding NULL check for tok
dlt_daemon_offline_logstorage.c : Adding NULL check for application
dlt_daemon_common.c : fix printf format %d to %ld that formats a long
dlt_common.c: fix printf format %d to %ld that formats a long
dlt_user.c : Fix for Memory Leak
dlt-daemon.c : Fix for Resource Leak
dlt_offline_trace.c : Fix for Resource Leak

Signed-off-by: Mvaradaraj2 <manoj.varadaraj2@harman.com>