### PR TITLE
Fix all processes using libdlt on Android terminating with SIGKILL

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -30,6 +30,7 @@ cc_defaults {
         "-DDLT_LIB_USE_UNIX_SOCKET_IPC",
         "-DCONFIGURATION_FILES_DIR=\"/vendor/etc\"",
         "-DDLT_USER_IPC_PATH=\"/data/local/tmp\"",
+        "-D_GNU_SOURCE",
     ] + [
         "-Wno-unused-parameter",
         "-W",


### PR DESCRIPTION
Android does not support `pthread_cancel()`, and never will, see https://android.googlesource.com/platform/bionic/+/master/docs/status.md . `dlt_stop_threads()` therefor tries to use `pthread_kill()` with `SIGKILL` to stop the housekeeping thread. This does not work as intended though. It forcefully kills the whole process, resulting in all processes using DLT on Android being terminated with `SIGKILL`.

Fix by using a pipe instead to wake housekeeping thread from `poll()` when it is time to exit. There are better mechanisms available on Linux, e.g. `eventfd()`, but use a pipe to limit differences between different platforms. `pipe2()` is used on Linux instead of `pipe()` to prevent `O_CLOEXEC`/`execv()` race in forking processes (`_GNU_SOURCE` needs to be defined on Android).

Even though `DLT_NETWORK_TRACE_ENABLE` is not supported on Android (no message queue implementation), make it so `pthread_cancel()` is not used there either by using a simple boolean variable. Allows for complete removal of `dlt_user_cleanup_handler()`.

Modifications in `dlt_user_log_check_user_message()` look larger than they are due to removal of "`if (fd != DLT_FD_INIT..`" block. Want to call `poll` regardless now to always poll pipe. `pollfd` events with fd < 0 are ignored, so it is OK to always pass the `pollfd` entry for incoming messages.

Should also note that prior to this commit, `poll()` was called with DLT_USER_RECEIVE_NDELAY which is in ns while `poll()` expects ms. So timeout passed to `poll()` was (500 * 10^(6-3) / 3600)s ~= 138.8h when building with FIFO for local IPC. Might as well always pass -1.