### PR TITLE
dlt_user_shared: Add timeout to writev

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -837,12 +837,17 @@ static int dlt_mkdir_recursive(const char *dir)
     for (p = tmp + 1; ((*p) && (ret == 0)) || ((ret == -1 && errno == EEXIST) && (p != end)); p++)
         if (*p == '/') {
             *p = 0;
-            ret = mkdir(tmp,
-            #ifdef DLT_DAEMON_USE_FIFO_IPC
-                        S_IRWXU);
-            #else
-                        S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH  | S_IWOTH /*S_IRWXU*/);
-            #endif
+
+            struct stat s;
+            if (stat(tmp, &s) == 0 && !S_ISDIR(s.st_mode)) {
+                ret = mkdir(tmp,
+                #ifdef DLT_DAEMON_USE_FIFO_IPC
+                                S_IRWXU);
+                #else
+                    S_IRUSR | S_IWUSR | S_IXUSR | S_IRGRP | S_IWGRP | S_IROTH  | S_IWOTH /*S_IRWXU*/);
+                #endif
+            }
+
             *p = '/';
         }
 


### PR DESCRIPTION
This timeout is necessary to prevent blocking writev indefinitely.
Without the timeout dlt-daemon, may block indefinitely when an app id is re-used
very frequently.
In that case dlt-daemon won't accept new connections and further communication
in any way is not possible anymore.

The setup of timeouts for sockets in `dlt_daemon_process_client_connect`
is not enough. 
Changed calls still can block for ever. 
It might be better to use timeoutOnSend but this would require 
more refactoring to pass the timeout to the log calls. 


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

Alexander Mohr, [alexander.m.mohr@daimler.com](mailto:alexander.m.mohr@daimler.com), Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)

Signed-off-by: Alexander Mohr <alexander.m.mohr@daimler.com>>