### PR TITLE
fixes compilation issue with clang

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -91,7 +91,7 @@
 #endif /* DLT_FATAL_LOG_RESET_ENABLE */
 
 static DltUser dlt_user;
-static bool dlt_user_initialised = false;
+static atomic_bool dlt_user_initialised = false;
 static int dlt_user_freeing = 0;
 static bool dlt_user_file_reach_max = false;
 
@@ -594,7 +594,7 @@ DltReturnValue dlt_set_filesize_max(unsigned int filesize)
     {
         dlt_vlog(LOG_ERR, "%s: Library is not configured to log to file\n",
                  __func__);
-        return DLT_LOG_ERROR;
+        return DLT_RETURN_ERROR;
     }
 
     if (filesize == 0) {


### PR DESCRIPTION
Hello all, 

Trying to compile the latest version available (2.18.8) with clang doesn't work anymore (see #338).

This PR is about fixing this issue : 
* function _atomic_compare_exchange_strong()_ expect a pointer to an **_Atomic** type. **dlt_user_initialised** is now an _atomic_bool_
* function _dlt_set_filesize_max()_ returned a DLT_LOG_ERROR which isn't a DltReturnValue. This commit replaces DLT_LOG_ERROR by DLT_RETURN_ERROR which is the expected return type