### PR TITLE
dlt-system : fix invalid free with ConfigurationFileName

### DIFF
--- a/src/system/dlt-system-options.c
+++ b/src/system/dlt-system-options.c
@@ -81,7 +81,7 @@ void usage(char *prog_name)
  */
 void init_cli_options(DltSystemCliOptions *options)
 {
-    options->ConfigurationFileName = DEFAULT_CONF_FILE;
+    options->ConfigurationFileName = strdup(DEFAULT_CONF_FILE);
     options->Daemonize = 0;
 }
 


### PR DESCRIPTION
when using default const string.

this location is free()'ed in the cleanup routine, leading to bugcheck upon
exit. Use strdup to allocate memory, that can be free()'ed.

Signed-off-by: Marc TITINGER <marc.titinger@non.se.com>

--
BR,
M.