### PR TITLE
dlt-system: optimize and fix name comparison for processes to check

### DIFF
--- a/src/system/dlt-system-options.c
+++ b/src/system/dlt-system-options.c
@@ -181,6 +181,7 @@ void init_configuration(DltSystemConfiguration *config)
 
     for (i = 0; i < DLT_SYSTEM_LOG_PROCESSES_MAX; i++) {
         config->LogProcesses.Name[i] = NULL;
+        config->LogProcesses.Name_sz[i] = 0U;
         config->LogProcesses.Filename[i] = NULL;
         config->LogProcesses.Mode[i] = 0;
         config->LogProcesses.TimeDelay[i] = 0;
@@ -383,6 +384,7 @@ int read_configuration_file(DltSystemConfiguration *config, char *file_name)
             }
             else if (strcmp(token, "LogProcessName") == 0)
             {
+                config->LogProcesses.Name_sz[config->LogProcesses.Count] = strlen(value);
                 config->LogProcesses.Name[config->LogProcesses.Count] = malloc(strlen(value) + 1);
                 MALLOC_ASSERT(config->LogProcesses.Name[config->LogProcesses.Count]);
                 strcpy(config->LogProcesses.Name[config->LogProcesses.Count], value); /* strcpy unritical here, because size matches exactly the size to be copied */

--- a/src/system/dlt-system-processes.c
+++ b/src/system/dlt-system-processes.c
@@ -90,8 +90,8 @@ void send_process(LogProcessOptions const *popts, int n)
                     fclose(pFile);
                 }
 
-                if ((strcmp((*popts).Name[n], "*") == 0) ||
-                    (strcmp(buffer, (*popts).Name[n]) == 0)) {
+                if (('*' == (*popts).Name[n][0]) ||
+                    (strncmp(buffer, (*popts).Name[n], (*popts).Name_sz[n]) == 0)) {
                     found = 1;
                     snprintf(filename, PATH_MAX, "/proc/%s/%s", dp->d_name, (*popts).Filename[n]);
                     pFile = fopen(filename, "r");

--- a/src/system/dlt-system.h
+++ b/src/system/dlt-system.h
@@ -166,6 +166,7 @@ typedef struct {
     /* Variable number of processes */
     int Count;
     char *Name[DLT_SYSTEM_LOG_PROCESSES_MAX];
+    unsigned int Name_sz[DLT_SYSTEM_LOG_PROCESSES_MAX];
     char *Filename[DLT_SYSTEM_LOG_PROCESSES_MAX];
     int Mode[DLT_SYSTEM_LOG_PROCESSES_MAX];
     int TimeDelay[DLT_SYSTEM_LOG_PROCESSES_MAX];


### PR DESCRIPTION
at the cost of one uint per monitored app, to store the cmdline size.
The first motivation of this patch is also to fix a bug, where cmdline
testing fails with some arguments following the program name.

Signed-off-by: Marc TITINGER <marc.titinger@non.se.com>

--
cheer,
M.