### PR TITLE
New data channel based on QNX Messaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ option(WITH_DLT_TESTS         "Set to ON to build src/test binaries"            
 option(WITH_DLT_UNIT_TESTS    "Set to ON to build gtest framework and tests/binaries"                            OFF)
 option(WITH_DLT_QNX_SYSTEM    "Set to ON to build QNX system binary dlt-qnx-system"                              OFF)
 
-set(DLT_IPC "FIFO" CACHE STRING "UNIX_SOCKET,FIFO")
+set(DLT_IPC "FIFO" CACHE STRING "UNIX_SOCKET,FIFO,QNX_MESSAGE")
 set(DLT_USER "genivi" CACHE STRING "Set user for process not run as root")
 
 option(WITH_DLT_PKGCONFIG     "Set to ON to generate pkgconfig .pc files"                                        ON)
@@ -121,7 +121,7 @@ include_directories(
 
 add_definitions(-D_GNU_SOURCE)
 
-if(NOT DLT_IPC STREQUAL "UNIX_SOCKET" AND NOT DLT_IPC STREQUAL "FIFO")
+if(NOT DLT_IPC STREQUAL "UNIX_SOCKET" AND NOT DLT_IPC STREQUAL "FIFO" AND NOT DLT_IPC STREQUAL "QNX_MESSAGE")
     message(FATAL_ERROR "${DLT_IPC} is not a valid value for DLT_IPC")
 endif()
 add_definitions(-DDLT_DAEMON_USE_${DLT_IPC}_IPC)

--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -111,6 +111,16 @@
 #      define DLT_PACKED
 #   endif
 
+#   ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+#      ifdef __QNX__
+#          include <sys/iofunc.h>
+#          include <sys/resmgr.h>
+#          include <sys/dispatch.h>
+#      else
+#          error DLT_IPC="QNX_MESSAGE" can only be built for QNX
+#      endif /* __QNX__ */
+#   endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
+
 /*
  * Macros to swap the byte order.
  */
@@ -410,6 +420,10 @@ typedef enum
     DLT_RECEIVE_SOCKET,
     DLT_RECEIVE_UDP_SOCKET,
     DLT_RECEIVE_FD
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+    DLT_RECEIVE_MSG,
+    DLT_CLIENT_RECEIVE_MSG,
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 } DltReceiverType;
 
 /**
@@ -784,6 +798,14 @@ typedef struct
     DltReceiverType type;     /**< type of connection handle */
     int32_t buffersize;       /**< size of receiver buffer */
     struct sockaddr_in addr;  /**< socket address information */
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+    resmgr_context_t *ctp;    /**< Context information that's passed between resource-manager functions */
+    int offset;               /**< offset for resmgr_msgread() */
+    int nbytes;               /**< received bytes  for resmgr_msgread() */
+    void *daemon;             /**< pointer to DltDaemon */
+    void *daemon_local;       /**< pointer to DltDaemonLocal */
+    name_attach_t *attach;
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 } DltReceiver;
 
 typedef struct

--- a/include/dlt/dlt_types.h
+++ b/include/dlt/dlt_types.h
@@ -184,7 +184,7 @@ typedef enum
 typedef float float32_t;
 typedef double float64_t;
 
-#if defined DLT_LIB_USE_UNIX_SOCKET_IPC || defined DLT_LIB_USE_VSOCK_IPC
+#if defined DLT_LIB_USE_UNIX_SOCKET_IPC || defined DLT_LIB_USE_VSOCK_IPC || DLT_LIB_USE_QNX_MESSAGE_IPC
 /**
  * Definition Library connection state
  */

--- a/include/dlt/dlt_user.h.in
+++ b/include/dlt/dlt_user.h.in
@@ -99,6 +99,14 @@
 #   include "dlt_user_macros.h"
 #endif
 
+#   ifdef DLT_LIB_USE_QNX_MESSAGE_IPC
+#      ifdef __QNX__
+#          include <sys/iofunc.h>
+#          include <sys/dispatch.h>
+#      else
+#          error DLT_IPC="QNX_MESSAGE" can only be built for QNX
+#      endif /* __QNX__ */
+#   endif /* DLT_LIB_USE_QNX_MESSAGE_IPC */
 #   ifdef __cplusplus
 extern "C" {
 #   endif
@@ -260,9 +268,12 @@ typedef struct
     int corrupt_message_size;
     int16_t corrupt_message_size_size;
 #   endif
-#   if defined DLT_LIB_USE_UNIX_SOCKET_IPC || defined DLT_LIB_USE_VSOCK_IPC
+#   if defined DLT_LIB_USE_UNIX_SOCKET_IPC || defined DLT_LIB_USE_VSOCK_IPC || DLT_LIB_USE_QNX_MESSAGE_IPC
     DltUserConnectionState connection_state;
 #   endif
+#ifdef DLT_LIB_USE_QNX_MESSAGE_IPC
+    name_attach_t *attach;
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
     uint16_t log_buf_len;        /**< length of message buffer, by default: DLT_USER_BUF_MAX_SIZE */
 } DltUser;
 

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -119,7 +119,7 @@ typedef struct
     unsigned int offlineLogstorageCacheSize; /**< Max cache size offline logstorage cache */
 #ifdef DLT_DAEMON_USE_UNIX_SOCKET_IPC
     char appSockPath[DLT_DAEMON_FLAG_MAX]; /**< Path to User socket */
-#else /* DLT_DAEMON_USE_FIFO_IPC */
+#elif defined DLT_DAEMON_USE_FIFO_IPC
     char userPipesDir[DLT_PATH_MAX]; /**< (String: Directory) directory where dltpipes reside (Default: /tmp/dltpipes) */
     char daemonFifoName[DLT_PATH_MAX]; /**< (String: Filename) name of local fifo (Default: /tmp/dlt) */
     char daemonFifoGroup[DLT_PATH_MAX]; /**< (String: Group name) Owner group of local fifo (Default: Primary Group) */
@@ -217,7 +217,9 @@ int dlt_daemon_process_systemd_timer(DltDaemon *daemon, DltDaemonLocal *daemon_l
 int dlt_daemon_process_control_connect(DltDaemon *daemon, DltDaemonLocal *daemon_local, DltReceiver *recv, int verbose);
 #if defined DLT_DAEMON_USE_UNIX_SOCKET_IPC || defined DLT_DAEMON_VSOCK_IPC_ENABLE
 int dlt_daemon_process_app_connect(DltDaemon *daemon, DltDaemonLocal *daemon_local, DltReceiver *recv, int verbose);
-#endif
+#elif DLT_DAEMON_USE_QNX_MESSAGE_IPC
+int dlt_daemon_call_process_user_func(DltReceiver *receiver);
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 int dlt_daemon_process_control_messages(DltDaemon *daemon, DltDaemonLocal *daemon_local, DltReceiver *recv,
                                         int verbose);
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1622,9 +1622,15 @@ void dlt_daemon_control_callsw_cinjection(int sock,
 
         /* write to FIFO */
         DltReturnValue ret =
-            dlt_user_log_out3(context->user_handle, &(userheader), sizeof(DltUserHeader),
-                              &(usercontext), sizeof(DltUserControlMsgInjection),
-                              userbuffer, (size_t) data_length_inject);
+#ifndef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+                dlt_user_log_out3(context->user_handle, &(userheader), sizeof(DltUserHeader),
+                                  &(usercontext), sizeof(DltUserControlMsgInjection),
+                                  userbuffer, (size_t) data_length_inject);
+#else
+                dlt_user_log_out3_qnx_msg(context->user_handle, &(userheader), sizeof(DltUserHeader),
+                                  &(usercontext), sizeof(DltUserControlMsgInjection),
+                                  userbuffer, (size_t) data_length_inject);
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 
         if (ret < DLT_RETURN_OK) {
             if (ret == DLT_RETURN_PIPE_ERROR) {

--- a/src/daemon/dlt_daemon_common.h
+++ b/src/daemon/dlt_daemon_common.h
@@ -82,6 +82,13 @@
 #   include "dlt_user.h"
 #   include "dlt_offline_logstorage.h"
 #   include "dlt_gateway_types.h"
+#   ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+#      ifdef __QNX__
+#          include <sys/dispatch.h>
+#      else
+#          error DLT_IPC="QNX_MESSAGE" can only be built for QNX
+#      endif /* __QNX__ */
+#   endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 
 #   ifdef __cplusplus
 extern "C" {
@@ -103,6 +110,25 @@ extern "C" {
 
 #define DLT_DAEMON_SEM_FREE() { sem_post(&dlt_daemon_mutex); }
 extern sem_t dlt_daemon_mutex;
+
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+    /** @brief Create logging resource manager.
+     *
+     * This function creates new instance of recource manager
+     * @param dpp indirection pointer to dispatch structure
+     * @param ctp indirection pointer to a dispatch context
+     * @param receiver indirection pointer to struct DltReceiver
+     * @return negative value if there was an error
+     */
+    DltReturnValue dlt_resmgr_create(dispatch_t **dpp, dispatch_context_t **ctp, DltReceiver **receiver);
+    /** @brief Destroys a channel.
+     *
+     * This function closes QNX messaging channel and frees receive structure.
+     * This is expected to be called by the connection owner: msg_thread.
+     * @param receiver pointer to struct DltReceiver
+     */
+    void dlt_resmgr_free(DltReceiver *receiver);
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 
 /* UDPMulticart Default IP and Port */
 #   ifdef UDP_CONNECTION_SUPPORT

--- a/src/daemon/dlt_daemon_connection.c
+++ b/src/daemon/dlt_daemon_connection.c
@@ -221,6 +221,9 @@ DLT_STATIC DltReceiver *dlt_connection_get_receiver(DltDaemonLocal *daemon_local
     case DLT_CONNECTION_APP_MSG:
         ret = calloc(1, sizeof(DltReceiver));
 
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+        receiver_type = DLT_RECEIVE_MSG;
+#else
         receiver_type = DLT_RECEIVE_FD;
 
         if (fstat(fd, &statbuf) == 0) {
@@ -230,6 +233,7 @@ DLT_STATIC DltReceiver *dlt_connection_get_receiver(DltDaemonLocal *daemon_local
             dlt_vlog(LOG_WARNING,
                      "Failed to determine receive type for DLT_CONNECTION_APP_MSG, using \"FD\"\n");
         }
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 
         if (ret)
             dlt_receiver_init_global_buffer(ret, fd, receiver_type, &app_recv_buffer);

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -76,6 +76,13 @@ char dltFifoBaseDir[DLT_PATH_MAX] = "/tmp";
 char dltShmName[NAME_MAX + 1] = "/dlt-shm";
 #endif
 
+#ifdef __QNX__
+#   include <errno.h>
+#   include <sys/neutrino.h>
+#   include <sys/types.h>
+#   include <sys/iofunc.h>
+#endif /* __QNX__ */
+
 /* internal logging parameters */
 static int logging_level = LOG_INFO;
 static char logging_filename[NAME_MAX + 1] = "";
@@ -2103,7 +2110,42 @@ int dlt_receiver_receive(DltReceiver *receiver)
         receiver->bytesRcvd = read(receiver->fd,
                                    receiver->buf + receiver->lastBytesRcvd,
                                    receiver->buffersize - (uint32_t) receiver->lastBytesRcvd);
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+    else if (receiver->type == DLT_CLIENT_RECEIVE_MSG)
+    {
+        /* wait for data from server of resource manager */
+        io_write_t whdr;
+        int recv_id = MsgReceive (receiver->attach->chid, &whdr, sizeof(whdr), NULL);
 
+        if (recv_id > 0) {
+            if (whdr.i.nbytes <= receiver->buffersize - (uint32_t) receiver->lastBytesRcvd) {
+                receiver->bytesRcvd = MsgRead (recv_id, receiver->buf + receiver->lastBytesRcvd, whdr.i.nbytes, sizeof (whdr));
+
+                if (receiver->bytesRcvd == -1) {
+                    dlt_vlog(LOG_ERR, "RecvMessage: MsgReadv returned an error! errno %d (%s))\n", errno, strerror(errno)); // NOLINT c-style vararg functions
+                }
+                else {
+                    MsgReply(recv_id, EOK, NULL, 0);
+                }
+            }
+            else {
+                dlt_vlog(LOG_ERR, "RecvMessage: Not enough space\n");
+            }
+        }
+        else if (errno != ETIMEDOUT && errno != EINTR) {
+            dlt_vlog(LOG_ERR, "RecvMessage: MsgReceive returned an error! errno %d (%s))\n", errno, strerror(errno)); // NOLINT c-style vararg functions
+        }
+    }
+    else if (receiver->type == DLT_RECEIVE_MSG)
+    {
+        /* wait for data from client of resource manager */
+        receiver->nbytes = resmgr_msgread(receiver->ctp,
+                                             receiver->buf + receiver->lastBytesRcvd,
+                                             receiver->buffersize - (uint32_t) receiver->lastBytesRcvd,
+                                             receiver->offset);
+        receiver->bytesRcvd = receiver->nbytes;
+    }
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
     else { /* receiver->type == DLT_RECEIVE_UDP_SOCKET */
         /* wait for data from UDP socket */
         addrlen = sizeof(receiver->addr);

--- a/src/shared/dlt_user_shared.h
+++ b/src/shared/dlt_user_shared.h
@@ -73,6 +73,15 @@
 
 #include <sys/types.h>
 
+#ifdef DLT_LIB_USE_QNX_MESSAGE_IPC
+#    ifdef __QNX__
+#        include <sys/iofunc.h>
+#        include <sys/dispatch.h>
+#    else
+#        error DLT_IPC="QNX_MESSAGE" can only be built for QNX
+#    endif /* __QNX__ */
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
+
 /**
  * This is the header of each message to be exchanged between application and daemon.
  */
@@ -223,5 +232,45 @@ DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2
  * @return Value from DltReturnValue enum
  */
 DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
+
+#ifdef DLT_DAEMON_USE_QNX_MESSAGE_IPC
+/** @brief Create QNX messaging channel for receiving new log levels from dlt-daemon.
+ *
+ * This function registers a name in the pathname space and create a channel
+ * @param attach - pointer to a name_attach_t structure that looks like this:
+ * typedef struct _name_attach {
+ *     dispatch_t* dpp;
+ *     int         chid;
+ *     int         mntid;
+ *     int         zero[2];
+ * } name_attach_t;
+ * @return negative value if there was an error
+ */
+DltReturnValue dlt_attach_channel(name_attach_t **attach);
+
+/**
+ * Atomic write to file descriptor, using vector of 2 elements
+ * @param handle file descriptor
+ * @param ptr1 generic pointer to first segment of data to be written
+ * @param len1 length of first segment of data to be written
+ * @param ptr2 generic pointer to second segment of data to be written
+ * @param len2 length of second segment of data to be written
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_out2_qnx_msg(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
+
+/**
+ * Atomic write to file descriptor, using vector of 3 elements
+ * @param handle file descriptor
+ * @param ptr1 generic pointer to first segment of data to be written
+ * @param len1 length of first segment of data to be written
+ * @param ptr2 generic pointer to second segment of data to be written
+ * @param len2 length of second segment of data to be written
+ * @param ptr3 generic pointer to third segment of data to be written
+ * @param len3 length of third segment of data to be written
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_out3_qnx_msg(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
+#endif /* DLT_DAEMON_USE_QNX_MESSAGE_IPC */
 
 #endif /* DLT_USER_SHARED_H */


### PR DESCRIPTION
- Add a new DLT-IPC "QNX_MESSAGE" based on the QNX messaging IPC
in addition to the two existing DLT-IPC: FIFO and UNIX_SOCKET.

The problem:
Message passing is the primary form of IPC in the QNX Neutrino
RTOS. POSIX IPC (TCP/IP sockets and pipes) are built over QNX
native message passing and sometimes it can cause 2 copies of
data, more context switches.

The solution:
Using of Resource Manager helps to simplify client-server
communication and switch DLT to QNX Neutrino Messaging instead
Unix sockets with minimum efforts without changing in DLT internal
logic.

The conclusions:
The main benefit of replacing Unix sockets with QNX Neutrino
Messaging is significant unloading of the networking manager
(io-pkt-v6-hc):
- CPU Usage ~ 9 times better;
- Inter CPU Communication (Cross CPU Messages) ~68 times better;
- CPU Migration ~ 2 times better.

DLT daemon utilizes more CPU recourses (instead of the network
driver), but this has not degraded overall performance.

Noticeable improvement in CPU usage has been achieved.