### PR TITLE
Forcibly the severity level set

### DIFF
--- a/src/dlt-qnx-system/dlt-qnx-slogger2-adapter.cpp
+++ b/src/dlt-qnx-system/dlt-qnx-slogger2-adapter.cpp
@@ -137,6 +137,9 @@ static int sloggerinfo_callback(slog2_packet_info_t *info, void *payload, void *
     if (param == NULL)
         return -1;
 
+    if (info->data_type == SLOG2_TYPE_ONLINE)
+        info->severity = SLOG2_INFO;
+
     DltLogLevelType loglevel;
     switch (info->severity)
     {


### PR DESCRIPTION
Problem:
Some QNX components when bringing up send messages of severity type "FATAL" instead of "INFO" via slogger2 . 

Root Cause:
QNX component send messages of payload data_type = SLOG2_TYPE_ONLINE. The buffer is new and just came online.
dlt-qnx-slogger2 does not support info->data_type = SLOG2_TYPE_ONLINE and therefore sets the wrong log level.

Solution:
Forcibly change the severity level for all info->data_type = SLOG2_TYPE_ONLINE to SLOG2_INFO.