### PR TITLE
fix for the issue #341

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2060,6 +2060,8 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
     cli_size = sizeof(cli);
 
     if ((in_sock = accept(receiver->fd, (struct sockaddr *)&cli, &cli_size)) < 0) {
+        if (errno == ECONNABORTED) // Caused by nmap -v -p 3490 -Pn <IP of dlt-daemon>
+            return 0;
         dlt_vlog(LOG_ERR, "accept() for socket %d failed: %s\n", receiver->fd, strerror(errno));
         return -1;
     }


### PR DESCRIPTION
The problem is described at https://github.com/GENIVI/dlt-daemon/issues/341. Scan of port 3490 from a Linux machine by
'nmap -v -p 3490 -Pn IP_address_of_QNX_board' leads to dlt-daemon crash.

The solution:
It is necessary to parse the code of the returned error in errno. If errno = ECONNABORTED it means there was an attempt to scan port 3490 and on this error there is no need to exit the application by error. 