### PR TITLE
fix -Wformat issues reported by clang

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1071,7 +1071,7 @@ DltReturnValue dlt_free(void)
                     if (bytes_read >= 0) {
                         if (!bytes_read)
                             break;
-                        dlt_vlog(LOG_NOTICE, "[%s] data is still readable... [%ld] bytes read\n",
+                        dlt_vlog(LOG_NOTICE, "[%s] data is still readable... [%zd] bytes read\n",
                                 __func__, bytes_read);
                     }
                 }
@@ -3878,7 +3878,7 @@ DltReturnValue dlt_user_log_send_log(DltContextData *log, int mtype)
             /* Get file size */
             struct stat st;
             fstat(dlt_user.dlt_log_handle, &st);
-            dlt_vlog(LOG_DEBUG, "%s: Current file size=[%ld]\n", __func__,
+            dlt_vlog(LOG_DEBUG, "%s: Current file size=[%jd]\n", __func__,
                      st.st_size);
 
             /* Check filesize */
@@ -3888,7 +3888,7 @@ DltReturnValue dlt_user_log_send_log(DltContextData *log, int mtype)
             if (msg_size > dlt_user.filesize_max) {
                 dlt_user_file_reach_max = true;
                 dlt_vlog(LOG_ERR,
-                         "%s: File size (%ld bytes) reached to defined maximum size (%d bytes)\n",
+                         "%s: File size (%jd bytes) reached to defined maximum size (%d bytes)\n",
                          __func__, st.st_size, dlt_user.filesize_max);
                 return DLT_RETURN_FILESZERR;
             }

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1488,7 +1488,7 @@ DltReturnValue dlt_file_open(DltFile *file, const char *filename, int verbose)
 
     if (verbose)
         /* print file length */
-        dlt_vlog(LOG_DEBUG, "File is %lu bytes long\n", file->file_length);
+        dlt_vlog(LOG_DEBUG, "File is %" PRIu64 "bytes long\n", file->file_length);
 
     return DLT_RETURN_OK;
 }
@@ -1521,14 +1521,14 @@ DltReturnValue dlt_file_read(DltFile *file, int verbose)
 
     /* set to end of last succesful read message, because of conflicting calls to dlt_file_read and dlt_file_message */
     if (0 != fseek(file->handle, file->file_position, SEEK_SET)) {
-        dlt_vlog(LOG_WARNING, "Seek failed to file_position %lu\n",
+        dlt_vlog(LOG_WARNING, "Seek failed to file_position %" PRIu64 "\n",
                  file->file_position);
         return DLT_RETURN_ERROR;
     }
 
     /* get file position at start of DLT message */
     if (verbose)
-        dlt_vlog(LOG_INFO, "Position in file: %lu\n", file->file_position);
+        dlt_vlog(LOG_INFO, "Position in file: %" PRIu64 "\n", file->file_position);
 
     /* read header */
     if (dlt_file_read_header(file, verbose) < DLT_RETURN_OK) {
@@ -1639,7 +1639,7 @@ DltReturnValue dlt_file_read_raw(DltFile *file, int resync, int verbose)
 
     /* get file position at start of DLT message */
     if (verbose)
-        dlt_vlog(LOG_DEBUG, "Position in file: %lu\n", file->file_position);
+        dlt_vlog(LOG_DEBUG, "Position in file: %" PRIu64 "\n", file->file_position);
 
     /* read header */
     if (dlt_file_read_header_raw(file, resync, verbose) < DLT_RETURN_OK) {
@@ -4148,7 +4148,7 @@ DltReturnValue dlt_file_quick_parsing(DltFile *file, const char *filename,
     while (ret >= DLT_RETURN_OK && file->file_position < file->file_length) {
         /* get file position at start of DLT message */
         if (verbose)
-            dlt_vlog(LOG_DEBUG, "Position in file: %lu\n", file->file_position);
+            dlt_vlog(LOG_DEBUG, "Position in file: %" PRIu64 "\n", file->file_position);
 
         /* read all header and payload */
         ret = dlt_file_read_header(file, verbose);


### PR DESCRIPTION
# Summary
This PR is about fixing compilation issues detected with clang on android 10 toolchain where -Werror and -Wformat are activated
# Description
* some previous dlt_vlog was using %lu specifier to display an uint64_t variable. However, this isn't portable as depending on the system you're targeting (32bits, 64bits, Linux, android, etc.), the uint64_t can be an unsigned long long. This prevents compilation on system where -Werror and -Wformat is activated coupled with a less tolerant compiler (e.g clang). Instead, PRIxN macros (e.g PRIu64 for uint64_t) are now used as specifier to ensure compatibility for each platforms
* for bytes_read which is of type ssize_t, zd specifier is used as indicated in C99 standard
* for st_size (from struct stat) which is of type off_t, POSIX says that it should be a signed integer. To be safe, we now use %jd specifier to ensure that it will fit correctly