### PR TITLE
filetransfer: Fix getFileCreationDate2 stat check

### DIFF
--- a/src/lib/dlt_filetransfer.c
+++ b/src/lib/dlt_filetransfer.c
@@ -179,7 +179,7 @@ void getFileCreationDate2(const char *file, int *ok, char *date)
 
     if (-1 == stat(file, &st)) {
         *ok = 0;
-        date = 0;
+        return;
     }
 
     *ok = 1;
@@ -259,7 +259,7 @@ void dlt_user_log_file_errorMessage(DltContext *fileContext, const char *filenam
                     DLT_STRING(filename));
         }
 
-        char fcreationdate[50];
+        char fcreationdate[50] = {0};
         getFileCreationDate2(filename, &ok, fcreationdate);
 
         if (!ok) {
@@ -326,7 +326,7 @@ int dlt_user_log_file_infoAbout(DltContext *fileContext, const char *filename)
                     DLT_STRING(filename));
         }
 
-        char creationdate[50];
+        char creationdate[50] = {0};
         getFileCreationDate2(filename, &ok, creationdate);
 
         if (!ok) {
@@ -475,7 +475,7 @@ int dlt_user_log_file_header_alias(DltContext *fileContext, const char *filename
                     DLT_STRING(filename));
         }
 
-        char fcreationdate[50];
+        char fcreationdate[50] = {0};
         getFileCreationDate2(filename, &ok, fcreationdate);
 
         if (!ok) {
@@ -536,7 +536,7 @@ int dlt_user_log_file_header(DltContext *fileContext, const char *filename)
                     DLT_STRING(filename));
         }
 
-        char fcreationdate[50];
+        char fcreationdate[50] = {0};
         getFileCreationDate2(filename, &ok, fcreationdate);
 
         if (!ok) {


### PR DESCRIPTION
Setting `date = 0;` and continuing the function execution will cause a segmentation fault when calling `asctime_r(&ts, date)`.

Signed-off-by: Andrei-Mircea Rusu <andrei-mircea.rusu@continental-corporation.com>