### PR TITLE
cmake: Add options to enable/disable each dlt console tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,11 @@ option(WITH_DLT_ADAPTOR       "Set to ON to build src/adaptor binaries"         
 option(WITH_DLT_CONSOLE       "Set to ON to build src/console binaries"                                          ON)
 option(WITH_DLT_CONSOLE_WO_CTRL    "Set to ON not to build control commands under src/console"                   OFF)
 option(WITH_DLT_CONSOLE_WO_SBTM    "Set to ON not to build dlt-sortbytimestamp under src/console"                OFF)
+option(WITH_DLT_CONSOLE_RECEIVE    "Set to OFF to skip building dlt_receive"                                     ON)
+option(WITH_DLT_CONSOLE_CONVERT    "Set to OFF to skip building dlt_convert"                                     ON)
+option(WITH_DLT_CONSOLE_CONTROL    "Set to OFF to skip building dlt_control"                                     ON)
+option(WITH_DLT_CONSOLE_PASSIVE_NODE_CTRL   "Set to OFF to skip building dlt_passive_node_ctrl"                  ON)
+
 option(WITH_DLT_EXAMPLES      "Set to ON to build src/examples binaries"                                         ON)
 option(WITH_DLT_FILETRANSFER  "Set to ON to build dlt-system with filetransfer support"                          OFF)
 option(WITH_DLT_SYSTEM        "Set to ON to build src/system binaries"                                           OFF)

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -17,11 +17,24 @@ set(dlt_control_common_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/dlt-control-common.c)
 add_library(dlt_control_common_lib STATIC ${dlt_control_common_SRCS})
 target_link_libraries(dlt_control_common_lib dlt ${DLT_JSON_LIBRARY})
 
-set(TARGET_LIST dlt-convert dlt-receive)
+set(TARGET_LIST "")
+
+if (WITH_DLT_CONSOLE_RECEIVE)
+    list(APPEND TARGET_LIST dlt-receive)
+endif()
+
+if (WITH_DLT_CONSOLE_CONVERT)
+    list(APPEND TARGET_LIST dlt-convert)
+endif()
 
 if(NOT WITH_DLT_CONSOLE_WO_CTRL)
     add_subdirectory(logstorage)
-    list(APPEND TARGET_LIST dlt-control dlt-passive-node-ctrl)
+    if (WITH_DLT_CONSOLE_CONTROL)
+        list(APPEND TARGET_LIST dlt-control)
+    endif()
+    if (WITH_DLT_CONSOLE_PASSIVE_NODE_CTRL)
+        list(APPEND TARGET_LIST dlt-passive-node-ctrl)
+    endif()
 endif()
 
 if(NOT WITH_DLT_CONSOLE_WO_SBTM)


### PR DESCRIPTION
This commits adds several cmake options to enable or disable
each console tool separately.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@daimler.com>, Daimler TSS GmbH, [imprint](https://github.com/Daimler/daimler-foss/blob/master/LEGAL_IMPRINT.md)</sup>
