### PR TITLE
Android: build fix

### DIFF
--- a/src/android/dlt-logd-converter.cpp
+++ b/src/android/dlt-logd-converter.cpp
@@ -51,7 +51,7 @@ static inline struct logger *init_logger(struct logger_list *logger_list, log_id
 static struct logger_list *init_logger_list(bool skip_binary_buffers)
 {
     struct logger_list *logger_list;
-    logger_list = android_logger_list_alloc(ANDROID_LOG_RDONLY, 0, 0);
+    logger_list = android_logger_list_alloc(0, 0, 0);
     if (logger_list == nullptr) {
         DLT_LOG(dlt_ctx_self, DLT_LOG_FATAL, DLT_STRING("could not allocate logger list"));
         return nullptr;


### PR DESCRIPTION
The macro ANDROID_LOG_RDONLY has been remove from include
files on the Android platform, resulting in compile time errors
due to using an undefined identifier, see:
https://android.googlesource.com/platform/system/logging/+/3d1687eb204821ae5df901bac210a31afd1d9970%5E%21/

Signed-off-by: Gabor Buella <gbuella@ford.com>