### PR TITLE
dlt_config_file_parser.c：Fix a pointer release bug in the file。

### DIFF
--- a/src/shared/dlt_config_file_parser.c
+++ b/src/shared/dlt_config_file_parser.c
@@ -148,6 +148,7 @@ static int dlt_config_file_set_section(DltConfigFile *file, char *name)
 
     if (s->keys == NULL) {
         free(s->name);
+        s->name = NULL;
         dlt_log(LOG_ERR, "Cannot allocate memory for internal data structure\n");
         return -1;
     }


### PR DESCRIPTION
In the dlt_config_file_set_section  function of  dlt_config_file_parser.c,  the following code exists:

 

s-name is not set to null after free.

 

It will be freed again in the dlt_config_file_release function.

