### PR TITLE
internal-logging: Fix issues with file logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ option(WITH_DLT_DBUS          "Set to ON to build src/dbus binaries"            
 option(WITH_DLT_TESTS         "Set to ON to build src/test binaries"                                             ON)
 option(WITH_DLT_UNIT_TESTS    "Set to ON to build gtest framework and tests/binaries"                            OFF)
 option(WITH_DLT_QNX_SYSTEM    "Set to ON to build QNX system binary dlt-qnx-system"                              OFF)
+option(WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK "Set to ON to enable fallback to syslog if dlt logging to file fails" OFF)
 
 set(DLT_IPC "FIFO" CACHE STRING "UNIX_SOCKET,FIFO")
 set(DLT_USER "genivi" CACHE STRING "Set user for process not run as root")
@@ -167,6 +168,10 @@ endif()
 
 if(WITH_DLT_QNX_SYSTEM AND NOT "${CMAKE_C_COMPILER}" MATCHES "nto-qnx|qcc")
     message(FATAL_ERROR "Can only compile for QNX with a QNX compiler.")
+endif()
+
+if (WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK)
+    add_definitions(-DWITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK)
 endif()
 
 if(WITH_GPROF)
@@ -336,6 +341,7 @@ message(STATUS "WITH_LIB_SHORT_VERSION = ${WITH_LIB_SHORT_VERSION}")
 message(STATUS "WITH_LEGACY_INCLUDE_PATH = ${WITH_LEGACY_INCLUDE_PATH}")
 message(STATUS "WITH_EXTENDED_FILTERING = ${WITH_EXTENDED_FILTERING}")
 message(STATUS "WITH_DLT_DISABLE_MACRO = ${WITH_DLT_DISABLE_MACRO}")
+message(STATUS "WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK = ${WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK}" )
 message(STATUS "Change a value with: cmake -D<Variable>=<Value>")
 message(STATUS "-------------------------------------------------------------------------------")
 message(STATUS)

--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -1195,7 +1195,7 @@ void dlt_print_with_attributes(bool state);
  * Initialize (external) logging facility
  * @param mode positive, 0 = log to stdout, 1 = log to syslog, 2 = log to file, 3 = log to stderr
  */
-void dlt_log_init(int mode);
+DltReturnValue dlt_log_init(int mode);
 /**
  * Print with variable arguments to specified file descriptor by DLT_LOG_MODE environment variable (like fprintf)
  * @param format format string for message

--- a/src/daemon/dlt.conf
+++ b/src/daemon/dlt.conf
@@ -46,6 +46,8 @@ LoggingMode = 0
 LoggingLevel = 6
 
 # The logging filename if internal logging mode is log to file (Default: /tmp/dlt.log)
+# If access to the file is not possible, the daemon will fall back to syslog
+# if WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK is set as compile flag
 LoggingFilename = /tmp/dlt.log
 
 # Timeout on send to client (sec)

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1803,11 +1803,11 @@ void dlt_print_with_attributes(bool state)
     print_with_attributes = state;
 }
 
-void dlt_log_init(int mode)
+DltReturnValue dlt_log_init(int mode)
 {
     if ((mode < DLT_LOG_TO_CONSOLE) || (mode > DLT_LOG_DROPPED)) {
         dlt_vlog(LOG_WARNING, "Wrong parameter for mode: %d\n", mode);
-        return;
+        return DLT_RETURN_WRONG_PARAMETER;
     }
 
     logging_mode = mode;
@@ -1818,14 +1818,16 @@ void dlt_log_init(int mode)
 
         if (logging_handle == NULL) {
             dlt_user_printf("Internal log file %s cannot be opened!\n", logging_filename);
-            return;
+            return DLT_RETURN_ERROR;
         }
     }
+
+    return DLT_RETURN_OK;
 }
 
 void dlt_log_free(void)
 {
-    if (logging_mode == DLT_LOG_TO_FILE)
+    if (logging_mode == DLT_LOG_TO_FILE && logging_handle)
         fclose(logging_handle);
 }
 


### PR DESCRIPTION
This commit fixes the following issues if access
to the internal log file is not possible (logging_mode = DLT_LOG_TO_FILE)
* dlt_log_free tried to call fclose on a nullptr
  Added a nullcheck for this
* Access to log file might be denied but access to logs is still wanted
  Add a new CMake option WITH_DLT_FILE_LOGGING_SYSLOG_FALLBACK
  If this is set to ON and the logging moe is set to file,
  the dlt-daemon will fall back to syslog if opening the internal log
  file failed

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>
