### PR TITLE
dlt-daemon-connection: Start up even if not all bindings are valid

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1621,6 +1621,7 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
         }
     }
     else {
+        bool any_open = false;
         while (head != NULL) { /* open socket for each IP in the bindAddress list */
 
             if (dlt_daemon_socket_open(&fd, daemon_local->flags.port, head->ip) == DLT_RETURN_OK) {
@@ -1629,16 +1630,21 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon,
                                           fd,
                                           POLLIN,
                                           DLT_CONNECTION_CLIENT_CONNECT)) {
-                    dlt_log(LOG_ERR, "Could not initialize main socket.\n");
-                    return DLT_RETURN_ERROR;
+                    dlt_vlog(LOG_ERR, "Could not create connection, for binding %s\n", head->ip);
+                } else {
+                    any_open = true;
                 }
             }
             else {
-                dlt_log(LOG_ERR, "Could not initialize main socket.\n");
-                return DLT_RETURN_ERROR;
+                dlt_vlog(LOG_ERR, "Could not open main socket, for binding %s\n", head->ip);
             }
 
             head = head->next;
+        }
+
+        if (!any_open) {
+            dlt_vlog(LOG_ERR, "Failed create main socket for any configured binding\n");
+            return DLT_RETURN_ERROR;
         }
     }
 


### PR DESCRIPTION
dlt-daemon allows configuration of multiple addresses.
Before this commit the daemon exits when the first binding fails.
This commit changes the behavior so that the daemon only exits
if none of the configured addresses can be opened.


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>
