### PR TITLE
dlt-gateway: Fix crash on invalid ip

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1045,7 +1045,7 @@ int main(int argc, char *argv[])
     /* initiate gateway */
     if (daemon_local.flags.gatewayMode == 1) {
         if (dlt_gateway_init(&daemon_local, daemon_local.flags.vflag) == -1) {
-            dlt_log(LOG_CRIT, "Fail to create gateway\n");
+            dlt_log(LOG_CRIT, "Failed to create gateway\n");
             return -1;
         }
 

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -791,6 +791,10 @@ int dlt_gateway_configure(DltGateway *gateway, char *config_file, int verbose)
                              configuration_entries[j].key, value);
             }
 
+            if (!tmp.ip_address) {
+                invalid = 1;
+            }
+
             if (invalid) {
                 dlt_vlog(LOG_ERR,
                          "%s configuration is invalid.\n"


### PR DESCRIPTION
* dlt-gateway crashed when an invalid
  ip address was configured as a null pointer
  was used for strdup

* Add timeout for dlt-client-connect.
  Timeout is hard coded to 1 seconds to prevent blocking
  the dlt-daemon overly long if a timeout is happening
  while creating a gateway connection.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>
