### PR TITLE
filetransfer: fix filesize divisible by blocksize case

### DIFF
--- a/src/lib/dlt_filetransfer.c
+++ b/src/lib/dlt_filetransfer.c
@@ -657,6 +657,13 @@ int dlt_user_log_file_data(DltContext *fileContext,
                 if (checkUserBufferForFreeSpace() > 0) {
                     pkgNumber++;
                     readBytes = fread(buffer, sizeof(char), BUFFER_SIZE, file);
+
+                    if (readBytes == 0) {
+                        // If the file size is divisible by the package size don't send
+                        // one empty FLDA. Also we send the correct number of FLDAs too.
+                        break;
+                    }
+
                     int ok;
 
                     uint32_t fserial = getFileSerialNumber(filename, &ok);


### PR DESCRIPTION
If the file size is divisible by the package size don't send one empty FLDA.
Also we send the correct number of FLDAs too.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Daniel Weber, [daniel.w.weber@mercedes-benz.com](mailto:daniel.w.weber@mercedes-benz.com), Mercedes-Benz Technology Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>