### PR TITLE
Logging to file: Add config option to overwrite log file

### DIFF
--- a/doc/dlt.conf.5.md
+++ b/doc/dlt.conf.5.md
@@ -79,6 +79,12 @@ If LoggingMode is set to 2 logs are written to the file path given here.
 
     Default: /tmp/dlt.log
 
+## LoggingFileMode
+
+If set to 1 overwrites LoggingFilename. If set to 0 appends LoggingFilename.
+
+    Default: 0
+
 ## TimeOutOnSend
 
 Socket timeout in seconds for sending to clients.

--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -1194,8 +1194,17 @@ void dlt_print_with_attributes(bool state);
 /**
  * Initialize (external) logging facility
  * @param mode positive, 0 = log to stdout, 1 = log to syslog, 2 = log to file, 3 = log to stderr
+ * @param overwrite_flag 1 = overwrite LoggingFilename, 0 = append LoggingFilename
  */
-void dlt_log_init(int mode);
+void dlt_log_init_p1(int mode, int overwrite_flag);
+
+/**
+ * Reinitialize (external) logging facility
+ * Should be called after dlt_log_init_p1() to reinitialize after fork
+ * @param mode positive, 0 = log to stdout, 1 = log to syslog, 2 = log to file, 3 = log to stderr
+ */
+void dlt_log_init_p2(int mode);
+
 /**
  * Print with variable arguments to specified file descriptor by DLT_LOG_MODE environment variable (like fprintf)
  * @param format format string for message

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -409,7 +409,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
     else
         filename = CONFIGURATION_FILES_DIR "/dlt.conf";
 
-    /*printf("Load configuration from file: %s\n",filename); */
+    dlt_vlog("Load configuration from file: %s\n",filename);
     pFile = fopen (filename, "r");
 
     if (pFile != NULL) {
@@ -528,6 +528,11 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                                 value,
                                 sizeof(daemon_local->flags.loggingFilename) - 1);
                         daemon_local->flags.loggingFilename[sizeof(daemon_local->flags.loggingFilename) - 1] = 0;
+                        /*printf("Option: %s=%s\n",token,value); */
+                    }
+                    else if (strcmp(token, "LoggingFileMode") == 0)
+                    {
+                        daemon_local->flags.fflag = atoi(value);
                         /*printf("Option: %s=%s\n",token,value); */
                     }
                     else if (strcmp(token, "TimeOutOnSend") == 0)
@@ -940,7 +945,7 @@ int main(int argc, char *argv[])
     /* Initialize internal logging facility */
     dlt_log_set_filename(daemon_local.flags.loggingFilename);
     dlt_log_set_level(daemon_local.flags.loggingLevel);
-    dlt_log_init(daemon_local.flags.loggingMode);
+    dlt_log_init_p1(daemon_local.flags.loggingMode, daemon_local.flags.fflag);
 
     /* Print version information */
     dlt_get_version(version, DLT_DAEMON_TEXTBUFSIZE);
@@ -1153,7 +1158,7 @@ int dlt_daemon_local_init_p1(DltDaemon *daemon, DltDaemonLocal *daemon_local, in
     /* Re-Initialize internal logging facility after fork */
     dlt_log_set_filename(daemon_local->flags.loggingFilename);
     dlt_log_set_level(daemon_local->flags.loggingLevel);
-    dlt_log_init(daemon_local->flags.loggingMode);
+    dlt_log_init_p2(daemon_local->flags.loggingMode);
 
     /* initialise structure to use DLT file */
     ret = dlt_file_init(&(daemon_local->file), daemon_local->flags.vflag);

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -93,6 +93,7 @@ typedef struct
     int rflag;      /**< (Boolean) Send automatic get log info response during context registration */
     int mflag;      /**< (Boolean) Sync to serial header on serial connection */
     int nflag;      /**< (Boolean) Sync to serial header on all TCP connections */
+    int fflag;      /**< (Boolean) Overwrite previous LoggingFilename */
     char evalue[NAME_MAX + 1];   /**< (String: ECU ID) Set ECU ID (Default: ECU1) */
     char bvalue[NAME_MAX + 1];   /**< (String: Baudrate) Serial device baudrate (Default: 115200) */
     char yvalue[NAME_MAX + 1];   /**< (String: Devicename) Additional support for serial device */

--- a/src/daemon/dlt.conf
+++ b/src/daemon/dlt.conf
@@ -48,6 +48,10 @@ LoggingLevel = 6
 # The logging filename if internal logging mode is log to file (Default: /tmp/dlt.log)
 LoggingFilename = /tmp/dlt.log
 
+# Overwrite previous LoggingFilename (Default: 0)
+# 0 = append LoggingFilename, 1 = overwrite LoggingFilename
+LoggingFileMode = 0
+
 # Timeout on send to client (sec)
 TimeOutOnSend = 4
 

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1814,7 +1814,7 @@ void dlt_print_with_attributes(bool state)
     print_with_attributes = state;
 }
 
-void dlt_log_init(int mode)
+void dlt_log_init_internal(int mode, const char* file_mode)
 {
     if ((mode < DLT_LOG_TO_CONSOLE) || (mode > DLT_LOG_DROPPED)) {
         dlt_vlog(LOG_WARNING, "Wrong parameter for mode: %d\n", mode);
@@ -1825,13 +1825,27 @@ void dlt_log_init(int mode)
 
     if (logging_mode == DLT_LOG_TO_FILE) {
         /* internal logging to file */
-        logging_handle = fopen(logging_filename, "a");
+        logging_handle = fopen(logging_filename, file_mode);
 
         if (logging_handle == NULL) {
             dlt_user_printf("Internal log file %s cannot be opened!\n", logging_filename);
             return;
         }
     }
+}
+
+void dlt_log_init_p1(int mode, int overwrite_flag)
+{
+    if (overwrite_flag) {
+        dlt_log_init_internal(mode, "w");
+    } else {
+        dlt_log_init_internal(mode, "a");
+    }
+}
+
+void dlt_log_init_p2(int mode)
+{
+    dlt_log_init_internal(mode, "a");
 }
 
 void dlt_log_free(void)
@@ -3992,7 +4006,7 @@ void dlt_check_envvar()
         int mode = 0;
 
         if (sscanf(env_log_mode, "%d", &mode))
-            dlt_log_init(mode);
+            dlt_log_init_p2(mode);
     }
 
 #if defined DLT_DAEMON_USE_FIFO_IPC || defined DLT_LIB_USE_FIFO_IPC


### PR DESCRIPTION
If dlt-daemon is configured to log to file, the log file will grow unlimited because it is always appended.