### PR TITLE
client: Fix Get Log Info response parse crash

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -4060,7 +4060,7 @@ int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count)
     num_work[4] = 0;
     *rp_count += 6;
 
-    return (unsigned char)strtol(num_work, &endptr, 16);
+    return (unsigned short)strtol(num_work, &endptr, 16);
 }
 
 int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count)


### PR DESCRIPTION
Fix wrong cast in `dlt_getloginfo_conv_ascii_to_uint16_t` which would lead to a crash if the read value would be more than 255.
Fix missing `count_app_ids = 0` in `dlt_client_free_calloc_failed_get_log_info` which causes a crash if this method would be called, as the final de-init method will iterate again and access free'd memory.
Fix usage of `dlt_getloginfo_conv_ascii_to_id` which requires a bigger buffer because it also sets a NULL terminator.


Signed-off-by: Andrei-Mircea Rusu <andrei-mircea.rusu@continental-corporation.com>