### PR TITLE
dlt_common.c: Change default logging_mode

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -81,7 +81,7 @@ char dltShmName[NAME_MAX + 1] = "/dlt-shm";
 static int logging_level = LOG_INFO;
 static char logging_filename[NAME_MAX + 1] = "";
 static bool print_with_attributes = false;
-int logging_mode = DLT_LOG_TO_CONSOLE;
+int logging_mode = DLT_LOG_TO_STDERR;
 FILE *logging_handle = NULL;
 
 char *message_type[] = { "log", "app_trace", "nw_trace", "control", "", "", "", "" };


### PR DESCRIPTION
Up to now the default for logging is stdout (DLT_LOG_TO_CONSOLE).

Scenario:
program_a arg1 | dd of=/my-beauty-case

If program_a wants to log to dlt, but it fails to connect to the socket: socket /run/dlt-files/dlt cannot be opened, error:Resource temporarily unavailable. Retrying later...

The error will be logged by default to stdout leading in the best case to an error and in the worst to damaged partitions.

To solve this log to STDERR (DLT_LOG_TO_STDERR) by default.