### PR TITLE
dlt_common: change output of message for log initialization

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1817,7 +1817,7 @@ void dlt_print_with_attributes(bool state)
 DltReturnValue dlt_log_init(int mode)
 {
     if ((mode < DLT_LOG_TO_CONSOLE) || (mode > DLT_LOG_DROPPED)) {
-        dlt_vlog(LOG_WARNING, "Wrong parameter for mode: %d\n", mode);
+        dlt_user_printf("Wrong parameter for mode: %d\n", mode);
         return DLT_RETURN_WRONG_PARAMETER;
     }
 


### PR DESCRIPTION
Switch dlt_vlog() to dlt_user_printf(), the message could be observed in case the log can not be written in file

Signed-off-by: Le Tin <tin.le@vn.bosch.com>