### PR TITLE
test-pr:fix bus error for ./dlt-receive -a localhost

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -307,7 +307,13 @@ enum {
         if ((length < 0) || ((length) < DLT_ID_SIZE)) \
         { length = -1; } \
         else \
-        { memcpy(dst, src, DLT_ID_SIZE); src += DLT_ID_SIZE; length -= DLT_ID_SIZE; } \
+        { 	uint8_t value_tmp_mac[sizeof(type)];	memset(value_tmp_mac, 0x00, sizeof(value_tmp_mac));\
+		uint8_t loop_tmp = 0;\
+		for (loop_tmp = 0; loop_tmp < sizeof(type); loop_tmp++)\
+		{value_tmp_mac[loop_tmp] = *((*ptr) + loop_tmp);}\
+		memcpy(&dst, value_tmp_mac, sizeof(type));\
+		src += sizeof(type); length -= sizeof(type); \
+		} \
     } while(0)
 
 #   define DLT_MSG_READ_STRING(dst, src, maxlength, dstlength, length) \


### PR DESCRIPTION
issue: fix bus error for ./dlt-receive -a localhost
analyze: at some times, we found some bus error in execute ./dlt-receive -a localhost, after i analyze , i found the address of "src" is odd number, in some system it will cause bus error.
fix: in some systems, the address shall follow byte alignment rule,so i changed the value-copy mechanism, please help review it.