### PR TITLE
Fix for Resource and Memory Leak

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1009,7 +1009,7 @@ int main(int argc, char *argv[])
         dlt_log(LOG_ERR, "Could not load runtime config\n");
         return -1;
     }
- 
+
     /*
      * Load dlt-runtime.cfg if available.
      * This must be loaded before offline setup
@@ -2157,6 +2157,8 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
 
         if (dlt_daemon_send_ringbuffer_to_client(daemon, daemon_local, verbose) == -1) {
             dlt_log(LOG_WARNING, "Can't send contents of ringbuffer to clients\n");
+            close(in_sock);
+            in_sock = -1;
             return -1;
         }
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1085,7 +1085,7 @@ void dlt_daemon_control_get_log_info(int sock,
                                                       daemon->ecuid,
                                                       verbose);
 
-            if (application) {
+            if ((user_list->applications) && (application)) {
                 /* Calculate start offset within contexts[] */
                 offset_base = 0;
 

--- a/src/daemon/dlt_daemon_offline_logstorage.c
+++ b/src/daemon/dlt_daemon_offline_logstorage.c
@@ -233,9 +233,14 @@ DLT_STATIC DltReturnValue dlt_logstorage_split_multi(char *key,
     else {
         strncpy(ecuid, tok, DLT_ID_SIZE);
         tok = strtok(NULL, ":");
-        strncpy(apid, tok, DLT_ID_SIZE);
+
+        if (tok != NULL)
+            strncpy(apid, tok, DLT_ID_SIZE);
+
         tok = strtok(NULL, ":");
-        strncpy(ctid, tok, DLT_ID_SIZE);
+
+        if (tok != NULL)
+            strncpy(ctid, tok, DLT_ID_SIZE);
     }
 
     return DLT_RETURN_OK;

--- a/src/shared/dlt_config_file_parser.c
+++ b/src/shared/dlt_config_file_parser.c
@@ -496,6 +496,7 @@ int dlt_config_file_get_section_name(const DltConfigFile *file,
         return -1;
 
     strncpy(name, (file->sections + num)->name, DLT_CONFIG_FILE_ENTRY_MAX_LEN);
+    name[DLT_CONFIG_FILE_ENTRY_MAX_LEN - 1] = '\0';
 
     return 0;
 }

--- a/src/shared/dlt_offline_trace.c
+++ b/src/shared/dlt_offline_trace.c
@@ -296,6 +296,9 @@ int dlt_offline_trace_delete_oldest_file(DltOfflineTrace *trace)
     /* go through all dlt files in directory */
     DIR *dir = opendir(trace->directory);
 
+    if(!dir)
+        return -1;
+
     while ((dp = readdir(dir)) != NULL)
         if (strstr(dp->d_name, DLT_OFFLINETRACE_FILENAME_BASE)) {
             int res = snprintf(filename, sizeof(filename), "%s/%s", trace->directory, dp->d_name);


### PR DESCRIPTION
dlt_daemon_client.c Adding NULL check for tok
dlt_daemon_offline_logstorage.c : Adding NULL check for application 
dlt_user.c : Fix for Memory Leak
dlt-daemon.c : Fix for Resource Leak
dlt_config_file_parser.c : Add termination character at the end of string 
dlt_offline_trace.c : Fix for Resource Leak

Signed-off-by: Mvaradaraj2 manoj.varadaraj2@harman.com