### PR TITLE
client: Fix Get Log Info response conversion method

### DIFF
--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -1211,6 +1211,7 @@ DLT_STATIC void dlt_client_free_calloc_failed_get_log_info(DltServiceGetLogInfoR
 
     free(resp->log_info_type.app_ids);
     resp->log_info_type.app_ids = NULL;
+    resp->log_info_type.count_app_ids = 0;
 
     return;
 }
@@ -1331,7 +1332,7 @@ DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoRespo
                 con->context_description = (char *)calloc
                         ((size_t) (con->len_context_description + 1), sizeof(char));
 
-                if (con->context_description == 0) {
+                if (con->context_description == NULL) {
                     dlt_vlog(LOG_ERR, "%s: calloc failed for context description\n", __func__);
                     dlt_client_free_calloc_failed_get_log_info(resp, i);
                     return DLT_RETURN_ERROR;
@@ -1351,7 +1352,7 @@ DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoRespo
             app->app_description = (char *)calloc
                     ((size_t) (app->len_app_description + 1), sizeof(char));
 
-            if (app->app_description == 0) {
+            if (app->app_description == NULL) {
                 dlt_vlog(LOG_ERR, "%s: calloc failed for application description\n", __func__);
                 dlt_client_free_calloc_failed_get_log_info(resp, i);
                 return DLT_RETURN_ERROR;

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -4062,7 +4062,7 @@ int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count)
     num_work[4] = 0;
     *rp_count += 6;
 
-    return (unsigned char)strtol(num_work, &endptr, 16);
+    return (uint16_t)strtol(num_work, &endptr, 16);
 }
 
 int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count)


### PR DESCRIPTION
Fix wrong cast in `dlt_getloginfo_conv_ascii_to_uint16_t` which would lead to a crash if the read value would be more than 255.
Fix missing `count_app_ids = 0` in` dlt_client_free_calloc_failed_get_log_info` which causes a crash if this method would be called, as the final de-init method will iterate again and access free'd memory.

Signed-off-by: Andrei-Mircea Rusu <andrei-mircea.rusu@continental-corporation.com>