### PR TITLE
dlt-convert: Fix memory leak by calling dlt_file_free

### DIFF
--- a/src/console/dlt-convert.c
+++ b/src/console/dlt-convert.c
@@ -420,6 +420,7 @@ int main(int argc, char *argv[])
                 if (ovalue)
                     close(ohandle);
 
+                dlt_file_free(&file, vflag);
                 return -1;
             }
 
@@ -428,6 +429,7 @@ int main(int argc, char *argv[])
                 if (ovalue)
                     close(ohandle);
 
+                dlt_file_free(&file, vflag);
                 return -1;
             }
 


### PR DESCRIPTION
Free the index which already allocated memory in dlt_file_read phase

Signed-off-by: Le Van Khanh <Khanh.LeVan@vn.bosch.com>