### PR TITLE
Fix memory leak

### DIFF
--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -124,6 +124,8 @@ void set_ecuid(char *ecuid)
             if (dlt_parse_config_param("ECUId", &ecuid_conf) == 0) {
                 memset(local_ecuid, 0, DLT_CTRL_ECUID_LEN);
                 strncpy(local_ecuid, ecuid_conf, DLT_CTRL_ECUID_LEN);
+                if (ecuid_conf !=NULL)
+                    free(ecuid_conf);
                 local_ecuid[DLT_CTRL_ECUID_LEN - 1] = '\0';
             }
             else {


### PR DESCRIPTION
Free the ecuid_conf in case of memory alllocated

Signed-off-by: Le Van Khanh <Khanh.LeVan@vn.bosch.com>