### PR TITLE
dlt-logd-converter: fixes android 12 compilation

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -194,9 +194,6 @@ cc_binary {
         "libdlt",
         "liblog",
     ],
-    include_dirs: [
-        "system/core/include",
-    ],
 }
 
 // vim: ft=python

--- a/src/android/dlt-logd-converter.cpp
+++ b/src/android/dlt-logd-converter.cpp
@@ -22,7 +22,6 @@
 #include <csignal>
 
 #include <log/log_read.h>
-#include <log/logprint.h>
 
 #include <dlt.h>
 
@@ -51,7 +50,7 @@ static inline struct logger *init_logger(struct logger_list *logger_list, log_id
 static struct logger_list *init_logger_list(bool skip_binary_buffers)
 {
     struct logger_list *logger_list;
-    logger_list = android_logger_list_alloc(ANDROID_LOG_RDONLY, 0, 0);
+    logger_list = android_logger_list_alloc(O_RDONLY, 0, 0);
     if (logger_list == nullptr) {
         DLT_LOG(dlt_ctx_self, DLT_LOG_FATAL, DLT_STRING("could not allocate logger list"));
         return nullptr;


### PR DESCRIPTION
# Summary
This PR is about fixing a compilation issue which appear starting on android 12 for android-logd-converter

# Description
* Since android 12 release (and the introduction of this [commit](https://chromium.googlesource.com/aosp/platform/system/logging/+/b674866203f05957b2ac5db94c3c0fe3d1d36793)), the macro ANDROID_LOG_RDONLY and friends have been removed (see the commit for the explanation). Therefore, dlt-logd-converter can't compile anymore since this version.
* The modification have been made in such way to allow dlt-logd-converter to compile also on version prior to android 12