### PR TITLE
Installs dlt.conf on android

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -60,6 +60,13 @@ genrule {
     out: ["dlt_user.h"],
 }
 
+prebuilt_etc {
+    name: "dlt-daemon-configuration",
+    vendor: true,
+    src: "src/daemon/dlt.conf",
+    filename_from_src: true,
+}
+
 cc_binary {
 
     name: "dlt-daemon",
@@ -103,6 +110,8 @@ cc_binary {
         "libutils",
         "libcutils",
     ],
+
+    required: ["dlt-daemon-configuration"],
 }
 
 cc_library_shared {


### PR DESCRIPTION
# Summary
This PR is about installing a dlt.conf along the dlt-daemon on android system.

# Description
* Currently on android, there is no dlt-daemon configuration installed by default. This change allows to install the dlt.conf along with the dlt-daemon during compilation phase.