### PR TITLE
dlt-user: fix crash with certain strings

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -221,7 +221,7 @@ static void dlt_user_trace_network_segmented_thread_segmenter(s_segmented_data *
 #endif
 
 static DltReturnValue dlt_user_log_write_string_utils_attr(DltContextData *log, const char *text, const enum StringType type, const char *name, bool with_var_info);
-static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData *log, const char *text, uint16_t length, const enum StringType type, const char *name, bool with_var_info);
+static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData *log, const char *text, size_t length, const enum StringType type, const char *name, bool with_var_info);
 
 
 static DltReturnValue dlt_unregister_app_util(bool force_sending_messages);
@@ -2606,7 +2606,7 @@ DltReturnValue dlt_user_log_write_sized_constant_utf8_string_attr(DltContextData
     return is_verbose_mode(dlt_user.verbose_mode, log) ? dlt_user_log_write_sized_utf8_string_attr(log, text, length, name) : DLT_RETURN_OK;
 }
 
-static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData *log, const char *text, uint16_t length, const enum StringType type, const char *name, bool with_var_info)
+static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData *log, const char *text, size_t length, const enum StringType type, const char *name, bool with_var_info)
 {
     if ((log == NULL) || (text == NULL))
         return DLT_RETURN_WRONG_PARAMETER;
@@ -2618,7 +2618,7 @@ static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData 
 
     const uint16_t name_size = (name != NULL) ? strlen(name)+1 : 0;
 
-    uint16_t arg_size = (uint16_t) (length + 1);
+    size_t arg_size = (size_t) (length + 1);
 
     size_t new_log_size = log->size + arg_size + sizeof(uint16_t);
 
@@ -2643,13 +2643,13 @@ static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData 
         ret = DLT_RETURN_USER_BUFFER_FULL;
 
         /* Re-calculate arg_size */
-        arg_size = (uint16_t) (dlt_user.log_buf_len - log->size - sizeof(uint16_t));
+        arg_size = (size_t) (dlt_user.log_buf_len - log->size - sizeof(uint16_t));
 
         size_t min_payload_str_truncate_msg = log->size + str_truncate_message_length + sizeof(uint16_t);
 
         if (is_verbose_mode(dlt_user.verbose_mode, log)) {
             min_payload_str_truncate_msg += sizeof(uint32_t);
-            arg_size -= (uint16_t) sizeof(uint32_t);
+            arg_size -= (size_t) sizeof(uint32_t);
             if (with_var_info) {
                 min_payload_str_truncate_msg += sizeof(uint16_t) + name_size;
                 arg_size -= sizeof(uint16_t) + name_size;
@@ -2687,7 +2687,7 @@ static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData 
             }
 
             max_payload_str_msg -= reduce_size;
-            arg_size -= (uint16_t) reduce_size;
+            arg_size -= (size_t) reduce_size;
         }
     }
 
@@ -2766,7 +2766,7 @@ static DltReturnValue dlt_user_log_write_string_utils_attr(DltContextData *log, 
     if ((log == NULL) || (text == NULL))
         return DLT_RETURN_WRONG_PARAMETER;
 
-    uint16_t length = (uint16_t) strlen(text);
+    size_t length = strlen(text);
     return dlt_user_log_write_sized_string_utils_attr(log, text, length, type, name, with_var_info);
 }
 
@@ -3276,7 +3276,7 @@ DltReturnValue dlt_user_trace_network_segmented(DltContext *handle,
         return DLT_RETURN_ERROR;
 
     /* Send as normal trace if possible */
-    if (header_len + payload_len + (uint16_t) sizeof(uint16_t) < dlt_user.log_buf_len)
+    if (header_len + payload_len + sizeof(uint16_t) < dlt_user.log_buf_len)
         return dlt_user_trace_network(handle, nw_trace_type, header_len, header, payload_len, payload);
 
     /* Allocate Memory */
@@ -3406,7 +3406,7 @@ DltReturnValue dlt_user_trace_network_truncated(DltContext *handle,
             header_len = 0;
 
         /* If truncation is allowed, check if we must do it */
-        if ((allow_truncate > 0) && ((header_len + payload_len + (uint16_t) sizeof(uint16_t)) > dlt_user.log_buf_len)) {
+        if ((allow_truncate > 0) && ((header_len + payload_len + sizeof(uint16_t)) > dlt_user.log_buf_len)) {
             /* Identify as truncated */
             if (dlt_user_log_write_string(&log, DLT_TRACE_NW_TRUNCATED) < DLT_RETURN_OK) {
                 dlt_user_free_buffer(&(log.buffer));


### PR DESCRIPTION
make sure that a string with exactly UINT16_MAX bytes does not overflow the dlt buffer

Given the example below there is a crash is libdlt 
```c++
#include <dlt/dlt.h>
#include <cstring>
#include <string>

DLT_DECLARE_CONTEXT(mycontext)

int main()
{
    DLT_REGISTER_APP("FOOB", "TEST DEMO");
    DLT_REGISTER_CONTEXT(mycontext, "CTX1", "Test Context for Logging");
    size_t len = 65535;
    char* txt = (char*)malloc(len);
    memset(txt, 'c', len);
    
    // will crash
    DLT_LOG(mycontext, DLT_LOG_INFO, DLT_STRING(txt));
}
```

The expansion of the macro looks like this
```c
do {
    DltContextData log_local;
    int dlt_local;
    dlt_local = dlt_user_log_write_start(&mycontext, &log_local, DLT_LOG_INFO);
    if (dlt_local == DLT_RETURN_TRUE) {
        (void)dlt_user_log_write_string(&log_local, txt);
        (void)dlt_user_log_write_finish(&log_local);
    }
} while (0
```

The crash now happens due to the following chain of events.
`dlt_user_log_write_start(&mycontext, &log_local, DLT_LOG_INFO);` is calling `dlt_user_log_write_string_utils_attr`
Which is casting the string length into `uint16_t`. This is fine as our string is exactly as long as `uint16_t` allows.
Now `dlt_user_log_write_sized_string_utils_attr` is called.
This sets `uint16_t arg_size = (uint16_t) (length + 1)`. Which will overflow the uint16_t and `arg_size` will be `0`.

```c
// new_log_size = 2
// will be increment to 6 if verbose mode is on
size_t new_log_size = log->size + arg_size + sizeof(uint16_t);
```

The code above also won't detect that the string is too large as the uin16_t also overflows and the sum will be much smaller as `dlt_user.log_buf_len` resulting in the truncation check to eval to false.

```c
/* Check log size condition */
if (new_log_size > dlt_user.log_buf_len)
// no jump into if body as new_log_size is small enough to fit into the buffer
// thus no truncation
```

Now `log->size` is incremented in several places. 
In my example with enabled verbose mode it's `6`

```c
 /* Whole string will be copied */
memcpy(log->buffer + log->size, text, length);
```

The code above is now copying into the buffer at `buffer + log->size`. 
As the original length with 65535 is used we're writing 6 bytes behind the actual buffer.
With larger strings, their length is still a multiple of `uint16_t max`, the same crash occurred.
If it's not a multiple the application does not crash but reads a certain amount of bytes from the buffer, truncating the log without any message that it was cut of.


It's fixed by using size_t for the calculation, so the truncation is working properly.

After the fix ` case DLT_RETURN_USER_BUFFER_FULL:` is used and the truncated string will be logged.
The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>