### PR TITLE
dlt-shared: add dlt_log_user with timeout

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -1622,7 +1622,7 @@ void dlt_daemon_control_callsw_cinjection(int sock,
 
         /* write to FIFO */
         DltReturnValue ret =
-            dlt_user_log_out3(context->user_handle, &(userheader), sizeof(DltUserHeader),
+            dlt_user_log_out3_with_timeout(context->user_handle, &(userheader), sizeof(DltUserHeader),
                               &(usercontext), sizeof(DltUserControlMsgInjection),
                               userbuffer, (size_t) data_length_inject);
 

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -1380,7 +1380,7 @@ int dlt_daemon_user_send_log_level(DltDaemon *daemon, DltDaemonContext *context,
 
     /* log to FIFO */
     errno = 0;
-    ret = dlt_user_log_out2(context->user_handle,
+    ret = dlt_user_log_out2_with_timeout(context->user_handle,
                             &(userheader), sizeof(DltUserHeader),
                             &(usercontext), sizeof(DltUserControlMsgLogLevel));
 
@@ -1416,7 +1416,7 @@ int dlt_daemon_user_send_log_state(DltDaemon *daemon, DltDaemonApplication *app,
     logstate.log_state = daemon->connectionState;
 
     /* log to FIFO */
-    ret = dlt_user_log_out2(app->user_handle,
+    ret = dlt_user_log_out2_with_timeout(app->user_handle,
                             &(userheader), sizeof(DltUserHeader),
                             &(logstate), sizeof(DltUserControlMsgLogState));
 

--- a/src/shared/dlt_user_shared.c
+++ b/src/shared/dlt_user_shared.c
@@ -71,6 +71,7 @@
 #include <errno.h>
 
 #include <sys/uio.h> /* writev() */
+#include <sys/time.h> /* timeval */
 
 #include "dlt_user_shared.h"
 #include "dlt_user_shared_cfg.h"
@@ -125,6 +126,28 @@ DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2
     return DLT_RETURN_OK;
 }
 
+DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2)
+{
+    if (handle < 0)
+        /* Invalid handle */
+        return DLT_RETURN_ERROR;
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(handle, &fds);
+
+    struct timeval tv = { 0, 100000000 };
+    if (select(handle+1, NULL, &fds, NULL, &tv) < 0) {
+        return DLT_RETURN_ERROR;
+    }
+
+    if (FD_ISSET(handle, &fds)) {
+        return dlt_user_log_out2(handle, ptr1, len1, ptr2, len2);
+    } else {
+        return DLT_RETURN_ERROR;
+    }
+}
+
 DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3)
 {
     struct iovec iov[3];
@@ -175,4 +198,26 @@ DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2
     }
 
     return DLT_RETURN_OK;
+}
+
+DltReturnValue dlt_user_log_out3_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3)
+{
+    if (handle < 0)
+        /* Invalid handle */
+        return DLT_RETURN_ERROR;
+
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(handle, &fds);
+
+    struct timeval tv = { 0, 100000000 };
+    if (select(handle+1, NULL, &fds, NULL, &tv) < 0) {
+        return DLT_RETURN_ERROR;
+    }
+
+    if (FD_ISSET(handle, &fds)) {
+        return dlt_user_log_out3(handle, ptr1, len1, ptr2, len2, ptr3, len3);
+    } else {
+        return DLT_RETURN_ERROR;
+    }
 }

--- a/src/shared/dlt_user_shared.h
+++ b/src/shared/dlt_user_shared.h
@@ -212,6 +212,17 @@ int dlt_user_check_userheader(DltUserHeader *userheader);
 DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
 
 /**
+ * Atomic write to file descriptor, using vector of 2 elements  with a timeout of 1s
+ * @param handle file descriptor
+ * @param ptr1 generic pointer to first segment of data to be written
+ * @param len1 length of first segment of data to be written
+ * @param ptr2 generic pointer to second segment of data to be written
+ * @param len2 length of second segment of data to be written
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
+
+/**
  * Atomic write to file descriptor, using vector of 3 elements
  * @param handle file descriptor
  * @param ptr1 generic pointer to first segment of data to be written
@@ -223,5 +234,18 @@ DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2
  * @return Value from DltReturnValue enum
  */
 DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
+
+/**
+ * Atomic write to file descriptor, using vector of 3 elements with a timeout of 1s
+ * @param handle file descriptor
+ * @param ptr1 generic pointer to first segment of data to be written
+ * @param len1 length of first segment of data to be written
+ * @param ptr2 generic pointer to second segment of data to be written
+ * @param len2 length of second segment of data to be written
+ * @param ptr3 generic pointer to third segment of data to be written
+ * @param len3 length of third segment of data to be written
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_log_out3_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
 
 #endif /* DLT_USER_SHARED_H */


### PR DESCRIPTION
if a client is not properly processing data
i.e. due to the client itself being slow or a
slow network connection, data should be
dropped instead of slowing the dlt-daemon down.
The later could lead to a systemd watchdog timeout or lost logs because the input buffer of the daemon will be filled completely.


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>