### PR TITLE
dltuser: add method to configure ring buffer size per application.

### DIFF
--- a/include/dlt/dlt_user.h.in
+++ b/include/dlt/dlt_user.h.in
@@ -1231,6 +1231,13 @@ int dlt_user_atexit_blow_out_user_buffer(void);
  */
 DltReturnValue dlt_user_log_resend_buffer(void);
 
+ /**
+ * Try to set max size of ring buffer for dlt user
+ * @param size new size of ring buffer in bytes
+ * @return Value from DltReturnValue enum
+ */
+DltReturnValue dlt_user_set_max_ring_buffer_size(uint32_t size);
+
 /**
  * Checks the log level passed by the log function if enabled for that context or not.
  * This function can be called by applications before generating their logs.

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -5130,3 +5130,13 @@ DltReturnValue dlt_user_log_out_error_handling(void *ptr1, size_t len1, void *pt
 
     return ret;
 }
+
+DltReturnValue dlt_user_set_max_ring_buffer_size(uint32_t size)
+{
+    DltBuffer * buf = &(dlt_user.startup_buffer);
+    if (size < buf->min_size) {
+        return DLT_RETURN_WRONG_PARAMETER;
+    }
+    buf->max_size = size;
+    return DLT_RETURN_OK;
+}


### PR DESCRIPTION
Logs of applications are kept in a ring buffer.
Each application (ie user) using logging functionality of dlt-daemon should be allowed to write
to ring buffer a limited asize of logs not to exceed limits available in terms of memory and performance. This patch is useful for upstream.
Because, first, the ability of limiting logs
of each application will make the use of system memory resources without exceeding the overall capacity limits. Secondly the logs of each pplication will be limited as a guard to excessive logging - ie logging in
for loops- which could not easily
be determined since most of them occur in extreme conditions.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>