### PR TITLE
build: add static lib only if necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,12 @@ else()
     set(PACKAGE_DOC "")
 endif()
 
+if (BUILD_SHARED_LIBS)
+    set(CMAKE_STATIC_LIB_PATH "")
+else()
+    set(CMAKE_STATIC_LIB_PATH "-L\$\{libdir\}/static")
+endif()
+
 if(WITH_DLT_PKGCONFIG)
     configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.spec.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.spec)
     configure_file(${PROJECT_SOURCE_DIR}/${PROJECT_NAME}.pc.in ${PROJECT_BINARY_DIR}/${PROJECT_NAME}.pc @ONLY)

--- a/automotive-dlt.pc.in
+++ b/automotive-dlt.pc.in
@@ -22,6 +22,6 @@ Name: DLT
 Description: Diagnostic Log and Trace
 Version: @PROJECT_VERSION@
 Requires:
-Libs: -L${libdir} -L${libdir}/static -ldlt -lrt -lpthread @ZLIB_LIBRARY@
+Libs: -L${libdir} @CMAKE_STATIC_LIB_PATH@ -ldlt -lrt -lpthread @ZLIB_LIBRARY@
 Cflags: -I${includedir}/dlt -I${includedir} -DDLT_@PROJECT_VERSION_MAJOR@_@PROJECT_VERSION_MINOR@
 


### PR DESCRIPTION
adding static library should only be enabled
if the dlt library is build static.
Adding this to the automotive-dlt.pc.in
when static libraries are disabled
yocto build will break


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>