### PR TITLE
fix usage of pthread_cond_timedwait

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -3775,9 +3775,7 @@ void dlt_user_housekeeperthread_function(void *ptr)
 
     // signal dlt thread to be running
     *dlt_housekeeper_running = true;
-    pthread_mutex_lock(&dlt_housekeeper_running_mutex);
     signal_status = pthread_cond_signal(&dlt_housekeeper_running_cond);
-    pthread_mutex_unlock(&dlt_housekeeper_running_mutex);
     if (signal_status != 0) {
         dlt_log(LOG_CRIT, "Housekeeper thread failed to signal running state\n");
     }


### PR DESCRIPTION
pthread_cond_timedwait has to be called with a locked mutex using an unlocked mutex is undefined behaviour
although it works on many platforms


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>