### PR TITLE
Update CMakeLists.txt: set required std version to gnu++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ endif()
 
 add_compile_options(
     $<$<COMPILE_LANGUAGE:C>:-std=gnu99>
-    $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++11>
+    $<$<COMPILE_LANGUAGE:CXX>:-std=gnu++14>
     -Wall
     -Wextra
     # -pedantic


### PR DESCRIPTION
New googletest 1.13.0 defaults to gnu++14, so makes this package FTBFS when building testsuite with this error:

In file included from /usr/include/gtest/gtest-message.h:57,
                 from /usr/include/gtest/gtest-assertion-result.h:46,
                 from /usr/include/gtest/gtest.h:64,
                 from /build/1st/dlt-daemon-2.18.9/tests/gtest_dlt_user.cpp:27:
/usr/include/gtest/internal/gtest-port.h:270:2: error: #error C++ versions less than C++14 are not supported.
  270 | #error C++ versions less than C++14 are not supported.
      |  ^~~~~

Thanks Adrian Bunk <bunk@debian.org> for the report and the fix!