### PR TITLE
Removed null-terminated from payload

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -2707,7 +2707,7 @@ static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData 
         memcpy(log->buffer + log->size, &type_info, sizeof(uint32_t));
         log->size += sizeof(uint32_t);
     }
-
+    
     memcpy(log->buffer + log->size, &arg_size, sizeof(uint16_t));
     log->size += sizeof(uint16_t);
 

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -2733,8 +2733,12 @@ static DltReturnValue dlt_user_log_write_sized_string_utils_attr(DltContextData 
     {
         /* Whole string will be copied */
         memcpy(log->buffer + log->size, text, length);
+
         /* The input string might not be null-terminated, so we're doing that by ourselves */
-        log->buffer[log->size + length] = '\0';
+        
+        /*The length of the string is already determined. Why need the null-terminator???*/
+        //log->buffer[log->size + length] = '\0';   //*[Deprecated]
+
         log->size += arg_size;
         break;
     }


### PR DESCRIPTION
On page 53 of the Autosar FO R22-11, the specification states the data payload of type String(STRG) must be constructed without a special terminator item such as '\0' 

@mbehr1 pointed out that since the length of the string is already determined, the need for a null terminator is useless in that context. 

**Before**
`case DLT_RETURN_OK: 
{ /* Whole string will be copied */
     memcpy(log->buffer + log->size, text, length); 
    **The input string might not be null-terminated, so we're doing that by ourselves** 
    log->buffer[log->size + length] = '\0'; 
    log->size += arg_size; 
    break; 
}`

**After** 
`    {
        /* Whole string will be copied */
        memcpy(log->buffer + log->size, text, length);

        /* The input string might not be null-terminated, so we're doing that by ourselves */

        /*The length of the string is already determined. Why need the null-terminator???*/
        //log->buffer[log->size + length] = '\0';   //*[Deprecated]

        log->size += arg_size;
        break;
    }`

I would like to know your thoughts on why this was added and if there was any specific meaning to this.