### PR TITLE
unittest: Fail with big-edian architecture 

### DIFF
--- a/tests/gtest_dlt_daemon_gateway.cpp
+++ b/tests/gtest_dlt_daemon_gateway.cpp
@@ -458,6 +458,10 @@ TEST(t_dlt_gateway_parse_get_log_info, normal)
     uint8_t status = 7;
     uint16_t count_app_ids = 1;
     uint16_t count_context_ids = 1;
+#if (BYTE_ORDER == BIG_ENDIAN)
+    count_app_ids = DLT_HTOLE_16(count_app_ids);
+    count_context_ids = DLT_HTOLE_16(count_context_ids);
+#endif
     const char *apid = "LOG";
     const char *ctid = "TEST";
     const char *com = "remo";
@@ -531,6 +535,10 @@ TEST(t_dlt_gateway_parse_get_log_info, normal)
 
     msg.standardheader = (DltStandardHeader *)(msg.headerbuffer + sizeof(DltStorageHeader));
     msg.standardheader->htyp = DLT_HTYP_WEID | DLT_HTYP_WTMS | DLT_HTYP_UEH | DLT_HTYP_PROTOCOL_VERSION1;
+#if (BYTE_ORDER == BIG_ENDIAN)
+    msg.standardheader->htyp = (msg.standardheader->htyp | DLT_HTYP_MSBF);
+#endif
+
     msg.standardheader->mcnt = 0;
 
     dlt_set_id(msg.headerextra.ecu, ecuid);


### PR DESCRIPTION
Swap some bytes makes it work on ppc64 and s390x

See: https://github.com/COVESA/dlt-daemon/issues/523