### PR TITLE
unittest: Add message header setup in Big-edian

### DIFF
--- a/.github/workflows/cmake-ctest-qemu.yml
+++ b/.github/workflows/cmake-ctest-qemu.yml
@@ -1,0 +1,33 @@
+name: CMake QEMU s390x-focal
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup multiarch/qemu-user-static
+      run: |
+        docker run --rm --privileged multiarch/qemu-user-static:register --reset
+    - name: ubuntu-core:s390x-focal
+      uses: docker://multiarch/ubuntu-core:s390x-focal
+      with:
+        args: >
+          bash -c "
+            TZ=America/Los_Angeles &&
+            ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone &&
+            apt-get update &&
+            apt -y install git cmake g++ zlib1g-dev libdbus-glib-1-dev build-essential &&
+            git clone https://github.com/COVESA/dlt-daemon.git &&
+            cd dlt-daemon &&
+            mkdir build &&
+            cd build &&
+            cmake .. -DWITH_DLT_UNIT_TESTS=ON &&
+            make -j 16 &&
+            ctest
+          "

--- a/tests/gtest_dlt_daemon_gateway.cpp
+++ b/tests/gtest_dlt_daemon_gateway.cpp
@@ -456,8 +456,8 @@ TEST(t_dlt_gateway_parse_get_log_info, normal)
     char ecuid[] = "ECU2";
     uint32_t sid = DLT_SERVICE_ID_GET_LOG_INFO;
     uint8_t status = 7;
-    uint16_t count_app_ids = 1;
-    uint16_t count_context_ids = 1;
+    uint16_t count_app_ids = DLT_HTOLE_16(1);
+    uint16_t count_context_ids =DLT_HTOLE_16(1);
     const char *apid = "LOG";
     const char *ctid = "TEST";
     const char *com = "remo";
@@ -531,6 +531,9 @@ TEST(t_dlt_gateway_parse_get_log_info, normal)
 
     msg.standardheader = (DltStandardHeader *)(msg.headerbuffer + sizeof(DltStorageHeader));
     msg.standardheader->htyp = DLT_HTYP_WEID | DLT_HTYP_WTMS | DLT_HTYP_UEH | DLT_HTYP_PROTOCOL_VERSION1;
+#if (BYTE_ORDER == BIG_ENDIAN)
+    msg.standardheader->htyp = (msg.standardheader->htyp | DLT_HTYP_MSBF);
+#endif
     msg.standardheader->mcnt = 0;
 
     dlt_set_id(msg.headerextra.ecu, ecuid);


### PR DESCRIPTION
+ Swap bit of apid, ctid counters
+ Turn ON MSBF in HTYP to use dlt in big-edian architecture
+ Github action: CI/CD for big-edian architecture
Reconstructed from: https://github.com/COVESA/dlt-daemon/pull/526