### PR TITLE
fix: Contact delimiter to log file name

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -91,7 +91,10 @@ void dlt_logstorage_log_file_name(char *log_file_name,
     /* create log file name */
     memset(log_file_name, '\0', DLT_MOUNT_PATH_MAX * sizeof(char));
     dlt_logstorage_concat_logfile_name(log_file_name, filter_config->file_name);
-    dlt_logstorage_concat_logfile_name(log_file_name, &file_config->logfile_delimiter);
+   
+    char logfile_delimiter[2] = { '\0' };
+    logfile_delimiter[0] = file_config->logfile_delimiter;
+    dlt_logstorage_concat_logfile_name(log_file_name, logfile_delimiter);
 
     snprintf(file_index, 10, "%d", idx);
 


### PR DESCRIPTION
There may be garbled codes after the delimiter in the offline log file name when concatenate the delimiter to the offline log file name if the delimiter' next char is not '\0' in memory.