### PR TITLE
connection: close connection when timeout cannot be set

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2144,7 +2144,7 @@ int dlt_daemon_process_client_connect(DltDaemon *daemon,
                               POLLIN,
                               DLT_CONNECTION_CLIENT_MSG_TCP)) {
         dlt_log(LOG_ERR, "Failed to register new client. \n");
-        /* TODO: Perform clean-up */
+        close(in_sock);
         return -1;
     }
 

--- a/src/daemon/dlt_daemon_connection.c
+++ b/src/daemon/dlt_daemon_connection.c
@@ -415,6 +415,12 @@ int dlt_connection_create(DltDaemonLocal *daemon_local,
 
     if (setsockopt (temp->receiver->fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof timeout) < 0)  {
         dlt_vlog(LOG_WARNING, "Unable to set send timeout %s.\n", strerror(errno));
+        // as this function is used for non socket connection as well
+        // we only can return an error here if it is a socket
+        if (errno != ENOTSOCK) {
+            free(temp);
+            return -1;
+        }
     }
 
     /* We are single threaded no need for protection. */


### PR DESCRIPTION
if a client disconnects at exactly the wrong time
we do not set a propper timeout for the socket
and do not disconnect the client either.
this commit removes the client connection
when setting the timeout failed.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>