### PR TITLE
dlt_cdh:

### DIFF
--- a/src/core_dump_handler/dlt_cdh.h
+++ b/src/core_dump_handler/dlt_cdh.h
@@ -45,7 +45,7 @@
 #define CORE_FILE_PATTERN           "%s/core.%d.%s.%d.gz"
 #define CONTEXT_FILE_PATTERN        "%s/context.%d.%s.%d.txt"
 
-#if ((__SIZEOF_POINTER) == 4)
+#if ((__SIZEOF_POINTER__) == 4)
 #define ELF_Ehdr    Elf32_Ehdr
 #define ELF_Phdr    Elf32_Phdr
 #define ELF_Shdr    Elf32_Shdr


### PR DESCRIPTION
Make sure on 64 bit we read an ELF64 structure.
Otherwise we get a read error, and the context file is missing some good to know information