### PR TITLE
Fix generating dlt version tag

### DIFF
--- a/util/create_dlt_version_h.py
+++ b/util/create_dlt_version_h.py
@@ -20,19 +20,13 @@ import re
 
 def get_cmd(cmd, cwd):
     return subprocess.check_output(cmd, cwd=cwd, shell=True,
-                                   stderr=subprocess.STDOUT
+                                   stderr=subprocess.DEVNULL,
                                    ).decode().strip()
 
 
 def get_revision(git_dir):
     try:
-        rev = get_cmd('git describe --tags', git_dir)
-        if not rev.startswith("fatal:"):
-            return rev
-
-        rev = get_cmd('git rev-parse HEAD', git_dir)
-        if not rev.startswith("fatal:"):
-            return rev
+        return get_cmd('git describe --tags --always --dirty', git_dir)
     except subprocess.CalledProcessError:
         pass
 


### PR DESCRIPTION
Update git describe to always produce some output. This allows to ignore git warnings and errors.

Fix problem when git warning about tag get placed in C++ header and a syntax error breaks build.

Example git output that prodcues compilation errors:
> git describe --tags
warning: tag 'haleytek/v2.18.5' is externally known as 'v2.18.5' v2.18.5-19-g344c37b