### PR TITLE
systemd: Don't install services in basic.target, but use multi-user.t…

### DIFF
--- a/systemd/dlt-dbus.service.cmake
+++ b/systemd/dlt-dbus.service.cmake
@@ -27,5 +27,5 @@ NotifyAccess=main
 LimitCORE=infinity
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target
 

--- a/systemd/dlt-system.service.cmake
+++ b/systemd/dlt-system.service.cmake
@@ -27,5 +27,5 @@ NotifyAccess=main
 LimitCORE=infinity
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target
 

--- a/systemd/dlt.service.cmake
+++ b/systemd/dlt.service.cmake
@@ -26,4 +26,4 @@ NotifyAccess=main
 LimitCORE=infinity
 
 [Install]
-WantedBy=basic.target
+WantedBy=multi-user.target


### PR DESCRIPTION
…arget instead.

The specified systemd service file declares an unusual WantedBy= relationship.

Most services that want to be started automatically at boot should use WantedBy=multi-user.target or WantedBy=graphical.target. Services that want to be started in rescue or single-user mode should instead use WantedBy=sysinit.target

Please refer to https://wiki.debian.org/Teams/pkg-systemd/rcSMigration for details.