### PR TITLE
add functionality to dump ring buffer to disk file

### DIFF
--- a/src/console/logstorage/dlt-logstorage-common.h
+++ b/src/console/logstorage/dlt-logstorage-common.h
@@ -28,6 +28,7 @@
 #define EVENT_UNMOUNTING    0
 #define EVENT_MOUNTED       1
 #define EVENT_SYNC_CACHE    2
+#define EVENT_DUMP_RING_BUFFER    3
 
 typedef enum
 {

--- a/src/console/logstorage/dlt-logstorage-ctrl.c
+++ b/src/console/logstorage/dlt-logstorage-ctrl.c
@@ -351,7 +351,7 @@ static int dlt_logstorage_ctrl_single_request()
     int ret = 0;
 
     /* in case sync all caches, an empty path is given */
-    if (get_default_event_type() != EVENT_SYNC_CACHE) {
+    if (get_default_event_type() != EVENT_SYNC_CACHE && get_default_event_type() != EVENT_DUMP_RING_BUFFER) {
         /* Check if a 'CONF_NAME' file is present at the given path */
         if (!dlt_logstorage_check_config_file(get_default_path())) {
             pr_error("No '%s' file available at: %s\n",
@@ -411,6 +411,7 @@ static void usage(void)
     printf("  -v --verbose               Set verbose flag (Default:%d)\n", get_verbosity());
     printf("  -C filename                DLT daemon configuration file (Default: " CONFIGURATION_FILES_DIR
            "/dlt.conf)\n");
+    printf("  -D --path                  Dump ring buffer to the path\n");
 }
 
 static struct option long_options[] = {
@@ -424,6 +425,7 @@ static struct option long_options[] = {
     {"send-header",   no_argument,        0,  'S'},
     {"resync-header", no_argument,        0,  'R'},
     {"verbose",       no_argument,        0,  'v'},
+    {"dump-buffer",   required_argument,  0,  'D'},
     {0,               0,                  0,  0}
 };
 
@@ -443,7 +445,7 @@ static int parse_args(int argc, char *argv[])
 
     while ((c = getopt_long(argc,
                             argv,
-                            ":s::t:hSRe:p:d::c:vC:",
+                            ":s::t:hSRe:p:d::c:vC:D:",
                             long_options,
                             &long_index)) != -1)
         switch (c) {
@@ -516,6 +518,19 @@ static int parse_args(int argc, char *argv[])
 
             usage();
             return -1;
+        case 'D':
+            {
+                set_default_event_type(EVENT_DUMP_RING_BUFFER);
+
+                if ((optarg != NULL) && (strlen(optarg) >= DLT_MOUNT_PATH_MAX)) {
+                    pr_error("Ring buffer dump path '%s' too long\n", optarg);
+                    return -1;
+                }
+
+                set_default_path(optarg);
+
+                break;
+            }
         default:
             pr_error("Try %s -h for more information.\n", argv[0]);
             return -1;

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -38,6 +38,7 @@ set(dlt_daemon_SRCS
     ${PROJECT_SOURCE_DIR}/src/shared/dlt_user_shared.c
     ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c
     ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+    dlt_buffer_dump.c
     )
 
 if(WITH_DLT_SHM_ENABLE)

--- a/src/daemon/dlt_buffer_dump.c
+++ b/src/daemon/dlt_buffer_dump.c
@@ -1,0 +1,72 @@
+/*
+* SPDX license identifier: MPL-2.0
+*
+* Copyright (C) 2022, Daimler TSS GmbH
+*
+* This file is part of COVESA Project DLT - Diagnostic Log and Trace.
+*
+* This Source Code Form is subject to the terms of the
+* Mozilla Public License (MPL), v. 2.0.
+* If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/.
+*
+* For further information see https://www.covesa.global/.
+*
+* \file dlt_buffer_dump.c
+*/
+
+#include "dlt_buffer_dump.h"
+#include "dlt-daemon_cfg.h"
+#include <syslog.h>
+#include <stdlib.h>
+#include <string.h>
+
+DltReturnValue dlt_ringbuffer_copy(const DltBuffer *src, DltBuffer *dst) {
+    if (src == NULL || dst == NULL) {
+        return DLT_RETURN_WRONG_PARAMETER;
+    }
+
+    dst->size = src->size;
+    dst->min_size = src->min_size;
+    dst->max_size = src->max_size;
+    dst->step_size = src->step_size;
+
+    int length = dst->size + sizeof(DltBufferHead);
+    dst->shm = malloc(length);
+    memcpy(dst->shm, src->shm, length);
+    dst->mem = (unsigned char *) (dst->shm + sizeof(DltBufferHead));
+
+    return DLT_RETURN_OK;
+}
+
+DltReturnValue dlt_buffer_dump(const DltDaemon *daemon, const DltBuffer *ring_buffer, const char *dump_file_path) {
+    uint8_t data[DLT_DAEMON_RCVBUFSIZE] = {0};
+    int length;
+    DltBuffer buffer = {0};
+
+    DltReturnValue ret = dlt_ringbuffer_copy(ring_buffer, &buffer);
+    if (ret != DLT_RETURN_OK) {
+        return ret;
+    }
+
+    FILE *file = fopen(dump_file_path, "w");
+    if (file == NULL) {
+        dlt_vlog(LOG_ERR, "Could not open dump file:%s\n", dump_file_path);
+        dlt_buffer_free_dynamic(&buffer);
+        return DLT_RETURN_WRONG_PARAMETER;
+    }
+
+    DltStorageHeader storage_header = {0};
+    dlt_set_storageheader(&storage_header, daemon->ecuid);
+
+    while ((length = dlt_buffer_copy(&buffer, data, sizeof(data))) > 0) {
+        fwrite(&storage_header, sizeof(DltStorageHeader), 1, file);
+        fwrite(&data, length, 1, file);
+        dlt_buffer_remove(&buffer);
+    }
+
+    fclose(file);
+    dlt_buffer_free_dynamic(&buffer);
+
+    return ret;
+}

--- a/src/daemon/dlt_buffer_dump.h
+++ b/src/daemon/dlt_buffer_dump.h
@@ -1,0 +1,42 @@
+/*
+* SPDX license identifier: MPL-2.0
+*
+* Copyright (C) 2022, Daimler TSS GmbH
+*
+* This file is part of COVESA Project DLT - Diagnostic Log and Trace.
+*
+* This Source Code Form is subject to the terms of the
+* Mozilla Public License (MPL), v. 2.0.
+* If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/.
+*
+* For further information see https://www.covesa.global/.
+*
+* \file dlt_buffer_dump.h
+ */
+
+#ifndef AUTOMOTIVE_DLT_SRC_DAEMON_DLT_BUFFER_DUMP_H_
+#define AUTOMOTIVE_DLT_SRC_DAEMON_DLT_BUFFER_DUMP_H_
+
+#include "dlt_client.h"
+#include "dlt_common.h"
+#include "dlt_daemon_common.h"
+
+/**
+ * Copy the ring buffer from src to dst
+ * @param src the ringbuffer source
+ * @param dst the ringbuffer dest
+ * @return DLT_RETURN OK if it is successful
+ */
+DltReturnValue dlt_ringbuffer_copy(const DltBuffer *src, DltBuffer *dst);
+
+/**
+ * dump the ringbuffer to disk
+ * @param daemon  the DltDaemon
+ * @param ring_buffer the ringbuffer
+ * @param dump_file_path the dump file path
+ * @return DLT_RETURN OK if it is successful
+ */
+DltReturnValue dlt_buffer_dump(const DltDaemon *daemon, const DltBuffer *ring_buffer, const char *dump_file_path);
+
+#endif //AUTOMOTIVE_DLT_SRC_DAEMON_DLT_BUFFER_DUMP_H_

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -65,6 +65,7 @@
 
 #include "dlt_daemon_offline_logstorage.h"
 #include "dlt_gateway.h"
+#include "dlt_buffer_dump.h"
 
 /** Inline function to calculate/set the requested log level or traces status
  *  with default log level or trace status when "ForceContextLogLevelAndTraceStatus"
@@ -2460,6 +2461,18 @@ void dlt_daemon_control_service_logstorage(int sock,
         return;
 
     req = (DltServiceOfflineLogstorage *)(msg->databuffer);
+
+    if(req->connection_type == DLT_OFFLINE_LOGSTORAGE_SYNC_RING_BUFFER) {
+        ret = dlt_buffer_dump(daemon, &(daemon->client_ringbuffer), req->mount_point);
+
+        dlt_daemon_control_service_response(sock,
+                                            daemon,
+                                            daemon_local,
+                                            DLT_SERVICE_ID_OFFLINE_LOGSTORAGE,
+                                            ret,
+                                            verbose);
+        return;
+    }
 
     if(req->connection_type != DLT_OFFLINE_LOGSTORAGE_SYNC_CACHES) {
         req_st_status = stat(req->mount_point, &req_mpoint_st);

--- a/src/offlinelogstorage/dlt_offline_logstorage.h
+++ b/src/offlinelogstorage/dlt_offline_logstorage.h
@@ -68,6 +68,7 @@
 #define DLT_OFFLINE_LOGSTORAGE_CONFIG_DONE              1
 
 #define DLT_OFFLINE_LOGSTORAGE_SYNC_CACHES              2 /* sync logstorage caches */
+#define DLT_OFFLINE_LOGSTORAGE_SYNC_RING_BUFFER         3 /* sync ring buffer */
 
 #define DLT_OFFLINE_LOGSTORAGE_MAX_KEY_LEN         15  /* Maximum size for key */
 #define DLT_OFFLINE_LOGSTORAGE_MAX_FILE_NAME_LEN   100 /* Maximum file name length of the log file including path under mount point */


### PR DESCRIPTION
For example:
/usr/bin/dlt-logstorage-ctrl -D /tmp/ss.dlt

will dump the entries in ringbuffer to file /tmp/ss.dlt