### PR TITLE
Limit set of exported symbols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.12)
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.20" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20")
     cmake_policy(SET CMP0115 OLD)

--- a/include/dlt/CMakeLists.txt
+++ b/include/dlt/CMakeLists.txt
@@ -19,11 +19,15 @@ endif()
 
 configure_file(dlt_user.h.in dlt_user.h)
 
+include(GenerateExportHeader)
+generate_export_header(dlt)
+
 set(HEADER_LIST dlt.h dlt_user_macros.h dlt_client.h dlt_protocol.h
                 dlt_common.h dlt_types.h dlt_shm.h dlt_offline_trace.h
                 dlt_filetransfer.h dlt_common_api.h dlt_multiple_files.h
                 ${CMAKE_CURRENT_BINARY_DIR}/dlt_version.h
-                ${CMAKE_CURRENT_BINARY_DIR}/dlt_user.h)
+                ${CMAKE_CURRENT_BINARY_DIR}/dlt_user.h
+                ${CMAKE_CURRENT_BINARY_DIR}/dlt_export.h)
 
 if(WITH_DLT_DISABLE_MACRO)
     list(REMOVE_ITEM HEADER_LIST dlt_user_macros.h)

--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -73,6 +73,7 @@
  \{
  */
 
+#   include "dlt_export.h"
 #   include "dlt_types.h"
 #   include "dlt_common.h"
 #include <stdbool.h>
@@ -106,8 +107,8 @@ typedef struct
 extern "C" {
 #   endif
 
-void dlt_client_register_message_callback(int (*registerd_callback)(DltMessage *message, void *data));
-void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(void *data));
+DLT_EXPORT void dlt_client_register_message_callback(int (*registerd_callback)(DltMessage *message, void *data));
+DLT_EXPORT void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(void *data));
 
 /**
  * Initialising dlt client structure with a specific port
@@ -116,7 +117,7 @@ void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-int dlt_client_init_port(DltClient *client, int port, int verbose);
+DLT_EXPORT int dlt_client_init_port(DltClient *client, int port, int verbose);
 
 /**
  * Initialising dlt client structure
@@ -124,21 +125,21 @@ int dlt_client_init_port(DltClient *client, int port, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_init(DltClient *client, int verbose);
+DLT_EXPORT DltReturnValue dlt_client_init(DltClient *client, int verbose);
 /**
  * Connect to dlt daemon using the information from the dlt client structure
  * @param client pointer to dlt client structure
  * @param verbose if set to true verbose information is printed out.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_connect(DltClient *client, int verbose);
+DLT_EXPORT DltReturnValue dlt_client_connect(DltClient *client, int verbose);
 /**
  * Cleanup dlt client structure
  * @param client pointer to dlt client structure
  * @param verbose if set to true verbose information is printed out.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_cleanup(DltClient *client, int verbose);
+DLT_EXPORT DltReturnValue dlt_client_cleanup(DltClient *client, int verbose);
 /**
  * Main Loop of dlt client application
  * @param client pointer to dlt client structure
@@ -146,7 +147,7 @@ DltReturnValue dlt_client_cleanup(DltClient *client, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_main_loop(DltClient *client, void *data, int verbose);
+DLT_EXPORT DltReturnValue dlt_client_main_loop(DltClient *client, void *data, int verbose);
 
 /**
  * Send a message to the daemon through the socket.
@@ -154,7 +155,7 @@ DltReturnValue dlt_client_main_loop(DltClient *client, void *data, int verbose);
  * @param msg The message to be send in DLT format.
  * @return Value from DltReturnValue enum.
  */
-DltReturnValue dlt_client_send_message_to_socket(DltClient *client, DltMessage *msg);
+DLT_EXPORT DltReturnValue dlt_client_send_message_to_socket(DltClient *client, DltMessage *msg);
 
 /**
  * Send ancontrol message to the dlt daemon
@@ -165,7 +166,7 @@ DltReturnValue dlt_client_send_message_to_socket(DltClient *client, DltMessage *
  * @param size Size of control message data
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_ctrl_msg(DltClient *client, char *apid, char *ctid, uint8_t *payload, uint32_t size);
+DLT_EXPORT DltReturnValue dlt_client_send_ctrl_msg(DltClient *client, char *apid, char *ctid, uint8_t *payload, uint32_t size);
 /**
  * Send an injection message to the dlt daemon
  * @param client pointer to dlt client structure
@@ -176,7 +177,7 @@ DltReturnValue dlt_client_send_ctrl_msg(DltClient *client, char *apid, char *cti
  * @param size Size of injection data within buffer
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_inject_msg(DltClient *client,
+DLT_EXPORT DltReturnValue dlt_client_send_inject_msg(DltClient *client,
                                           char *apid,
                                           char *ctid,
                                           uint32_t serviceID,
@@ -190,35 +191,35 @@ DltReturnValue dlt_client_send_inject_msg(DltClient *client,
  * @param logLevel Log Level
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_log_level(DltClient *client, char *apid, char *ctid, uint8_t logLevel);
+DLT_EXPORT DltReturnValue dlt_client_send_log_level(DltClient *client, char *apid, char *ctid, uint8_t logLevel);
 /**
  * Send an request to get log info message to the dlt daemon
  * @param client pointer to dlt client structure
  * @return negative value if there was an error
  */
-int dlt_client_get_log_info(DltClient *client);
+DLT_EXPORT int dlt_client_get_log_info(DltClient *client);
 /**
  * Send an request to get default log level to the dlt daemon
  * @param client pointer to dlt client structure
  * @return negative value if there was an error
  */
-DltReturnValue dlt_client_get_default_log_level(DltClient *client);
+DLT_EXPORT DltReturnValue dlt_client_get_default_log_level(DltClient *client);
 /**
  * Send an request to get software version to the dlt daemon
  * @param client pointer to dlt client structure
  * @return negative value if there was an error
  */
-int dlt_client_get_software_version(DltClient *client);
+DLT_EXPORT int dlt_client_get_software_version(DltClient *client);
 /**
  * Initialise get log info structure
  * @return void
  */
-void dlt_getloginfo_init(void);
+DLT_EXPORT void dlt_getloginfo_init(void);
 /**
  * To free the memory allocated for app description in get log info
  * @return void
  */
-void dlt_getloginfo_free(void);
+DLT_EXPORT void dlt_getloginfo_free(void);
 /**
  * Send a set trace status message to the dlt daemon
  * @param client pointer to dlt client structure
@@ -227,54 +228,54 @@ void dlt_getloginfo_free(void);
  * @param traceStatus Default Trace Status
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_trace_status(DltClient *client, char *apid, char *ctid, uint8_t traceStatus);
+DLT_EXPORT DltReturnValue dlt_client_send_trace_status(DltClient *client, char *apid, char *ctid, uint8_t traceStatus);
 /**
  * Send the default log level to the dlt daemon
  * @param client pointer to dlt client structure
  * @param defaultLogLevel Default Log Level
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_default_log_level(DltClient *client, uint8_t defaultLogLevel);
+DLT_EXPORT DltReturnValue dlt_client_send_default_log_level(DltClient *client, uint8_t defaultLogLevel);
 /**
  * Send the log level to all contexts registered with dlt daemon
  * @param client pointer to dlt client structure
  * @param LogLevel Log Level to be set
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_all_log_level(DltClient *client, uint8_t LogLevel);
+DLT_EXPORT DltReturnValue dlt_client_send_all_log_level(DltClient *client, uint8_t LogLevel);
 /**
  * Send the default trace status to the dlt daemon
  * @param client pointer to dlt client structure
  * @param defaultTraceStatus Default Trace Status
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_default_trace_status(DltClient *client, uint8_t defaultTraceStatus);
+DLT_EXPORT DltReturnValue dlt_client_send_default_trace_status(DltClient *client, uint8_t defaultTraceStatus);
 /**
  * Send the trace status to all contexts registered with dlt daemon
  * @param client pointer to dlt client structure
  * @param traceStatus trace status to be set
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_all_trace_status(DltClient *client, uint8_t traceStatus);
+DLT_EXPORT DltReturnValue dlt_client_send_all_trace_status(DltClient *client, uint8_t traceStatus);
 /**
  * Send the timing pakets status to the dlt daemon
  * @param client pointer to dlt client structure
  * @param timingPakets Timing pakets enabled
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_timing_pakets(DltClient *client, uint8_t timingPakets);
+DLT_EXPORT DltReturnValue dlt_client_send_timing_pakets(DltClient *client, uint8_t timingPakets);
 /**
  * Send the store config command to the dlt daemon
  * @param client pointer to dlt client structure
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_store_config(DltClient *client);
+DLT_EXPORT DltReturnValue dlt_client_send_store_config(DltClient *client);
 /**
  * Send the reset to factory default command to the dlt daemon
  * @param client pointer to dlt client structure
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_send_reset_to_factory_default(DltClient *client);
+DLT_EXPORT DltReturnValue dlt_client_send_reset_to_factory_default(DltClient *client);
 
 /**
  * Set baudrate within dlt client structure
@@ -282,7 +283,7 @@ DltReturnValue dlt_client_send_reset_to_factory_default(DltClient *client);
  * @param baudrate Baudrate
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_setbaudrate(DltClient *client, int baudrate);
+DLT_EXPORT DltReturnValue dlt_client_setbaudrate(DltClient *client, int baudrate);
 
 /**
  * Set mode within dlt client structure
@@ -290,7 +291,7 @@ DltReturnValue dlt_client_setbaudrate(DltClient *client, int baudrate);
  * @param mode DltClientMode
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_set_mode(DltClient *client, DltClientMode mode);
+DLT_EXPORT DltReturnValue dlt_client_set_mode(DltClient *client, DltClientMode mode);
 
 /**
  * Set server ip
@@ -298,7 +299,7 @@ DltReturnValue dlt_client_set_mode(DltClient *client, DltClientMode mode);
  * @param ipaddr pointer to command line argument
  * @return negative value if there was an error
  */
-int dlt_client_set_server_ip(DltClient *client, char *ipaddr);
+DLT_EXPORT int dlt_client_set_server_ip(DltClient *client, char *ipaddr);
 
 /**
  * Set server UDP host receiver interface address
@@ -306,7 +307,7 @@ int dlt_client_set_server_ip(DltClient *client, char *ipaddr);
  * @param hostip pointer to multicast group address
  * @return negative value if there was an error
  */
-int dlt_client_set_host_if_address(DltClient *client, char *hostip);
+DLT_EXPORT int dlt_client_set_host_if_address(DltClient *client, char *hostip);
 
 /**
  * Set serial device
@@ -314,7 +315,7 @@ int dlt_client_set_host_if_address(DltClient *client, char *hostip);
  * @param serial_device pointer to command line argument
  * @return negative value if there was an error
  */
-int dlt_client_set_serial_device(DltClient *client, char *serial_device);
+DLT_EXPORT int dlt_client_set_serial_device(DltClient *client, char *serial_device);
 
 /**
  * Set socket path
@@ -322,7 +323,7 @@ int dlt_client_set_serial_device(DltClient *client, char *serial_device);
  * @param socket_path pointer to socket path string
  * @return negative value if there was an error
  */
-int dlt_client_set_socket_path(DltClient *client, char *socket_path);
+DLT_EXPORT int dlt_client_set_socket_path(DltClient *client, char *socket_path);
 
 /**
  * Parse GET_LOG_INFO response text
@@ -330,7 +331,7 @@ int dlt_client_set_socket_path(DltClient *client, char *socket_path);
  * @param resp_text response text represented by ASCII
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
+DLT_EXPORT DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoResponse *resp,
                                                        char *resp_text);
 
 /**
@@ -338,7 +339,7 @@ DltReturnValue dlt_client_parse_get_log_info_resp_text(DltServiceGetLogInfoRespo
  * @param resp response
  * @return 0 on success, -1 otherwise
  */
-int dlt_client_cleanup_get_log_info(DltServiceGetLogInfoResponse *resp);
+DLT_EXPORT int dlt_client_cleanup_get_log_info(DltServiceGetLogInfoResponse *resp);
 #   ifdef __cplusplus
 }
 #   endif

--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -100,6 +100,7 @@
 #      include <termios.h>
 #   endif
 
+#   include "dlt_export.h"
 #   include "dlt_types.h"
 #   include "dlt_protocol.h"
 
@@ -415,25 +416,25 @@ typedef enum
 /**
  * The definition of the serial header containing the characters "DLS" + 0x01.
  */
-extern const char dltSerialHeader[DLT_ID_SIZE];
+DLT_EXPORT extern const char dltSerialHeader[DLT_ID_SIZE];
 
 /**
  * The definition of the serial header containing the characters "DLS" + 0x01 as char.
  */
-extern char dltSerialHeaderChar[DLT_ID_SIZE];
+DLT_EXPORT extern char dltSerialHeaderChar[DLT_ID_SIZE];
 
 #if defined DLT_DAEMON_USE_FIFO_IPC || defined DLT_LIB_USE_FIFO_IPC
 /**
  * The common base-path of the dlt-daemon-fifo and application-generated fifos
  */
-extern char dltFifoBaseDir[DLT_PATH_MAX];
+DLT_EXPORT extern char dltFifoBaseDir[DLT_PATH_MAX];
 #endif
 
 #ifdef DLT_SHM_ENABLE
 /**
  * The common name of the dlt-daemon and application share memory
  */
-extern char dltShmName[NAME_MAX + 1];
+DLT_EXPORT extern char dltShmName[NAME_MAX + 1];
 #endif
 
 /**
@@ -839,7 +840,7 @@ extern "C"
  * @param ptr pointer to the byte array.
  * @param size number of bytes to be printed.
  */
-void dlt_print_hex(uint8_t *ptr, int size);
+DLT_EXPORT void dlt_print_hex(uint8_t *ptr, int size);
 /**
  * Helper function to print a byte array in hex into a string.
  * @param text pointer to a ASCII string, in which the text is written
@@ -848,7 +849,7 @@ void dlt_print_hex(uint8_t *ptr, int size);
  * @param size number of bytes to be printed.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_print_hex_string(char *text, int textlength, uint8_t *ptr, int size);
+DLT_EXPORT DltReturnValue dlt_print_hex_string(char *text, int textlength, uint8_t *ptr, int size);
 /**
  * Helper function to print a byte array in hex and ascii into a string.
  * @param text pointer to a ASCII string, in which the text is written
@@ -858,7 +859,7 @@ DltReturnValue dlt_print_hex_string(char *text, int textlength, uint8_t *ptr, in
  * @param html output is html? 0 - false, 1 - true
  * @return negative value if there was an error
  */
-DltReturnValue dlt_print_mixed_string(char *text, int textlength, uint8_t *ptr, int size, int html);
+DLT_EXPORT DltReturnValue dlt_print_mixed_string(char *text, int textlength, uint8_t *ptr, int size, int html);
 /**
  * Helper function to print a byte array in ascii into a string.
  * @param text pointer to a ASCII string, in which the text is written
@@ -867,7 +868,7 @@ DltReturnValue dlt_print_mixed_string(char *text, int textlength, uint8_t *ptr, 
  * @param size number of bytes to be printed.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_print_char_string(char **text, int textlength, uint8_t *ptr, int size);
+DLT_EXPORT DltReturnValue dlt_print_char_string(char **text, int textlength, uint8_t *ptr, int size);
 
 /**
  * Helper function to determine a bounded length of a string.
@@ -878,28 +879,28 @@ DltReturnValue dlt_print_char_string(char **text, int textlength, uint8_t *ptr, 
  * @param maxsize maximal considered length of @a str
  * @return the bounded length of the string
  */
-PURE_FUNCTION size_t dlt_strnlen_s(const char* str, size_t maxsize);
+DLT_EXPORT PURE_FUNCTION size_t dlt_strnlen_s(const char* str, size_t maxsize);
 
 /**
  * Helper function to print an id.
  * @param text pointer to ASCII string where to write the id
  * @param id four byte char array as used in DLT mesages as IDs.
  */
-void dlt_print_id(char *text, const char *id);
+DLT_EXPORT void dlt_print_id(char *text, const char *id);
 
 /**
  * Helper function to set an ID parameter.
  * @param id four byte char array as used in DLT mesages as IDs.
  * @param text string to be copied into char array.
  */
-void dlt_set_id(char *id, const char *text);
+DLT_EXPORT void dlt_set_id(char *id, const char *text);
 
 /**
  * Helper function to remove not nice to print characters, e.g. NULL or carage return.
  * @param text pointer to string to be cleaned.
  * @param length length of string excluding terminating zero.
  */
-void dlt_clean_string(char *text, int length);
+DLT_EXPORT void dlt_clean_string(char *text, int length);
 
 /**
  * Initialise the filter list.
@@ -908,14 +909,14 @@ void dlt_clean_string(char *text, int length);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_init(DltFilter *filter, int verbose);
+DLT_EXPORT DltReturnValue dlt_filter_init(DltFilter *filter, int verbose);
 /**
  * Free the used memory by the organising structure of filter.
  * @param filter pointer to structure of organising DLT filter
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_free(DltFilter *filter, int verbose);
+DLT_EXPORT DltReturnValue dlt_filter_free(DltFilter *filter, int verbose);
 /**
  * Load filter list from file.
  * @param filter pointer to structure of organising DLT filter
@@ -923,7 +924,7 @@ DltReturnValue dlt_filter_free(DltFilter *filter, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verbose);
+DLT_EXPORT DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verbose);
 /**
  * Save filter in space separated list to text file.
  * @param filter pointer to structure of organising DLT filter
@@ -931,7 +932,7 @@ DltReturnValue dlt_filter_load(DltFilter *filter, const char *filename, int verb
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_save(DltFilter *filter, const char *filename, int verbose);
+DLT_EXPORT DltReturnValue dlt_filter_save(DltFilter *filter, const char *filename, int verbose);
 /**
  * Find index of filter in filter list
  * @param filter pointer to structure of organising DLT filter
@@ -943,7 +944,7 @@ DltReturnValue dlt_filter_save(DltFilter *filter, const char *filename, int verb
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error (or not found), else return index of filter
  */
-int dlt_filter_find(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
+DLT_EXPORT int dlt_filter_find(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
                                 const int32_t payload_min, const int32_t payload_max, int verbose);
 /**
  * Add new filter to filter list.
@@ -956,7 +957,7 @@ int dlt_filter_find(DltFilter *filter, const char *apid, const char *ctid, const
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_add(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
+DLT_EXPORT DltReturnValue dlt_filter_add(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
                                 const int32_t payload_min, const int32_t payload_max, int verbose);
 /**
  * Delete filter from filter list
@@ -969,7 +970,7 @@ DltReturnValue dlt_filter_add(DltFilter *filter, const char *apid, const char *c
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_filter_delete(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
+DLT_EXPORT DltReturnValue dlt_filter_delete(DltFilter *filter, const char *apid, const char *ctid, const int log_level,
                                 const int32_t payload_min, const int32_t payload_max, int verbose);
 
 /**
@@ -979,14 +980,14 @@ DltReturnValue dlt_filter_delete(DltFilter *filter, const char *apid, const char
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_init(DltMessage *msg, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_init(DltMessage *msg, int verbose);
 /**
  * Free the used memory by the organising structure of file.
  * @param msg pointer to structure of organising access to DLT messages
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_free(DltMessage *msg, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_free(DltMessage *msg, int verbose);
 /**
  * Print Header into an ASCII string.
  * This function calls dlt_message_header_flags() with flags=DLT_HEADER_SHOW_ALL
@@ -996,7 +997,7 @@ DltReturnValue dlt_message_free(DltMessage *msg, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_header(DltMessage *msg, char *text, size_t textlength, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_header(DltMessage *msg, char *text, size_t textlength, int verbose);
 /**
  * Print Header into an ASCII string, selective.
  * @param msg pointer to structure of organising access to DLT messages
@@ -1006,7 +1007,7 @@ DltReturnValue dlt_message_header(DltMessage *msg, char *text, size_t textlength
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, size_t textlength, int flags, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, size_t textlength, int flags, int verbose);
 /**
  * Print Payload into an ASCII string.
  * @param msg pointer to structure of organising access to DLT messages
@@ -1016,7 +1017,7 @@ DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, size_t text
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_payload(DltMessage *msg, char *text, size_t textlength, int type, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_payload(DltMessage *msg, char *text, size_t textlength, int type, int verbose);
 /**
  * Check if message is filtered or not. All filters are applied (logical OR).
  * @param msg pointer to structure of organising access to DLT messages
@@ -1024,7 +1025,7 @@ DltReturnValue dlt_message_payload(DltMessage *msg, char *text, size_t textlengt
  * @param verbose if set to true verbose information is printed out.
  * @return 1 = filter matches, 0 = filter does not match, negative value if there was an error
  */
-DltReturnValue dlt_message_filter_check(DltMessage *msg, DltFilter *filter, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_filter_check(DltMessage *msg, DltFilter *filter, int verbose);
 
 /**
  * Read message from memory buffer.
@@ -1036,7 +1037,7 @@ DltReturnValue dlt_message_filter_check(DltMessage *msg, DltFilter *filter, int 
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-int dlt_message_read(DltMessage *msg, uint8_t *buffer, unsigned int length, int resync, int verbose);
+DLT_EXPORT int dlt_message_read(DltMessage *msg, uint8_t *buffer, unsigned int length, int resync, int verbose);
 
 /**
  * Get standard header extra parameters
@@ -1044,7 +1045,7 @@ int dlt_message_read(DltMessage *msg, uint8_t *buffer, unsigned int length, int 
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_get_extraparameters(DltMessage *msg, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_get_extraparameters(DltMessage *msg, int verbose);
 
 /**
  * Set standard header extra parameters
@@ -1052,7 +1053,7 @@ DltReturnValue dlt_message_get_extraparameters(DltMessage *msg, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_set_extraparameters(DltMessage *msg, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_set_extraparameters(DltMessage *msg, int verbose);
 
 /**
  * Initialise the structure used to access a DLT file.
@@ -1061,7 +1062,7 @@ DltReturnValue dlt_message_set_extraparameters(DltMessage *msg, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_init(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_init(DltFile *file, int verbose);
 /**
  * Set a list to filters.
  * This function should be called before loading a DLT file, if filters should be used.
@@ -1072,7 +1073,7 @@ DltReturnValue dlt_file_init(DltFile *file, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_set_filter(DltFile *file, DltFilter *filter, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_set_filter(DltFile *file, DltFilter *filter, int verbose);
 /**
  * Initialising loading a DLT file.
  * @param file pointer to structure of organising access to DLT file
@@ -1080,7 +1081,7 @@ DltReturnValue dlt_file_set_filter(DltFile *file, DltFilter *filter, int verbose
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_open(DltFile *file, const char *filename, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_open(DltFile *file, const char *filename, int verbose);
 /**
  * This function reads DLT file and parse DLT message one by one.
  * Each message will be written into new file.
@@ -1091,7 +1092,7 @@ DltReturnValue dlt_file_open(DltFile *file, const char *filename, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return 0 = message does not match filter, 1 = message was read, negative value if there was an error
  */
-DltReturnValue dlt_file_quick_parsing(DltFile *file, const char *filename, int type, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_quick_parsing(DltFile *file, const char *filename, int type, int verbose);
 /**
  * Find next message in the DLT file and parse them.
  * This function finds the next message in the DLT file.
@@ -1100,7 +1101,7 @@ DltReturnValue dlt_file_quick_parsing(DltFile *file, const char *filename, int t
  * @param verbose if set to true verbose information is printed out.
  * @return 0 = message does not match filter, 1 = message was read, negative value if there was an error
  */
-DltReturnValue dlt_file_read(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read(DltFile *file, int verbose);
 /**
  * Find next message in the DLT file in RAW format (without storage header) and parse them.
  * This function finds the next message in the DLT file.
@@ -1110,21 +1111,21 @@ DltReturnValue dlt_file_read(DltFile *file, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return 0 = message does not match filter, 1 = message was read, negative value if there was an error
  */
-DltReturnValue dlt_file_read_raw(DltFile *file, int resync, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read_raw(DltFile *file, int resync, int verbose);
 /**
  * Closing loading a DLT file.
  * @param file pointer to structure of organising access to DLT file
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_close(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_close(DltFile *file, int verbose);
 /**
  * Load standard header of a message from file
  * @param file pointer to structure of organising access to DLT file
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_read_header(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read_header(DltFile *file, int verbose);
 /**
  * Load standard header of a message from file in RAW format (without storage header)
  * @param file pointer to structure of organising access to DLT file
@@ -1132,7 +1133,7 @@ DltReturnValue dlt_file_read_header(DltFile *file, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_read_header_raw(DltFile *file, int resync, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read_header_raw(DltFile *file, int resync, int verbose);
 /**
  * Load, if available in message, extra standard header fields and
  * extended header of a message from file
@@ -1141,7 +1142,7 @@ DltReturnValue dlt_file_read_header_raw(DltFile *file, int resync, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_read_header_extended(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read_header_extended(DltFile *file, int verbose);
 /**
  * Load payload of a message from file
  * (dlt_file_read_header() must have been called before this call!)
@@ -1149,7 +1150,7 @@ DltReturnValue dlt_file_read_header_extended(DltFile *file, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_read_data(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_read_data(DltFile *file, int verbose);
 /**
  * Load headers and payload of a message selected by the index.
  * If filters are set, index is based on the filtered list.
@@ -1158,64 +1159,64 @@ DltReturnValue dlt_file_read_data(DltFile *file, int verbose);
  * @param verbose if set to true verbose information is printed out.
  * @return number of messages loaded, negative value if there was an error
  */
-DltReturnValue dlt_file_message(DltFile *file, int index, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_message(DltFile *file, int index, int verbose);
 /**
  * Free the used memory by the organising structure of file.
  * @param file pointer to structure of organising access to DLT file
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_file_free(DltFile *file, int verbose);
+DLT_EXPORT DltReturnValue dlt_file_free(DltFile *file, int verbose);
 
 /**
  * Set internal logging filename if mode 2
  * @param filename the filename
  */
-void dlt_log_set_filename(const char *filename);
+DLT_EXPORT void dlt_log_set_filename(const char *filename);
 #if defined DLT_DAEMON_USE_FIFO_IPC || defined DLT_LIB_USE_FIFO_IPC
 /**
  * Set FIFO base direction
  * @param pipe_dir the pipe direction
  */
-void dlt_log_set_fifo_basedir(const char *pipe_dir);
+DLT_EXPORT void dlt_log_set_fifo_basedir(const char *pipe_dir);
 #endif
 /**
  * Set internal logging level
  * @param level the level
  */
-void dlt_log_set_level(int level);
+DLT_EXPORT void dlt_log_set_level(int level);
 
 /**
  * Set whether to print "name" and "unit" attributes in console output
  * @param state  true = with attributes, false = without attributes
  */
-void dlt_print_with_attributes(bool state);
+DLT_EXPORT void dlt_print_with_attributes(bool state);
 
 /**
  * Initialize (external) logging facility
  * @param mode positive, 0 = log to stdout, 1 = log to syslog, 2 = log to file, 3 = log to stderr
  */
-DltReturnValue dlt_log_init(int mode);
+DLT_EXPORT DltReturnValue dlt_log_init(int mode);
 /**
  * Print with variable arguments to specified file descriptor by DLT_LOG_MODE environment variable (like fprintf)
  * @param format format string for message
  * @return negative value if there was an error or the total number of characters written is returned on success
  */
-int dlt_user_printf(const char *format, ...) PRINTF_FORMAT(1, 2);
+DLT_EXPORT int dlt_user_printf(const char *format, ...) PRINTF_FORMAT(1, 2);
 /**
  * Log ASCII string with null-termination to (external) logging facility
  * @param prio priority (see syslog() call)
  * @param s Pointer to ASCII string with null-termination
  * @return negative value if there was an error
  */
-DltReturnValue dlt_log(int prio, char *s);
+DLT_EXPORT DltReturnValue dlt_log(int prio, char *s);
 /**
  * Log with variable arguments to (external) logging facility (like printf)
  * @param prio priority (see syslog() call)
  * @param format format string for log message
  * @return negative value if there was an error
  */
-DltReturnValue dlt_vlog(int prio, const char *format, ...) PRINTF_FORMAT(2, 3);
+DLT_EXPORT DltReturnValue dlt_vlog(int prio, const char *format, ...) PRINTF_FORMAT(2, 3);
 /**
  * Log size bytes with variable arguments to (external) logging facility (similar to snprintf)
  * @param prio priority (see syslog() call)
@@ -1223,11 +1224,11 @@ DltReturnValue dlt_vlog(int prio, const char *format, ...) PRINTF_FORMAT(2, 3);
  * @param format format string for log message
  * @return negative value if there was an error
  */
-DltReturnValue dlt_vnlog(int prio, size_t size, const char *format, ...) PRINTF_FORMAT(3, 4);
+DLT_EXPORT DltReturnValue dlt_vnlog(int prio, size_t size, const char *format, ...) PRINTF_FORMAT(3, 4);
 /**
  * De-Initialize (external) logging facility
  */
-void dlt_log_free(void);
+DLT_EXPORT void dlt_log_free(void);
 
 /**
  * Initialising a dlt receiver structure
@@ -1237,13 +1238,13 @@ void dlt_log_free(void);
  * @param _buffersize size of data buffer for storing the received data
  * @return negative value if there was an error
  */
-DltReturnValue dlt_receiver_init(DltReceiver *receiver, int _fd, DltReceiverType type, int _buffersize);
+DLT_EXPORT DltReturnValue dlt_receiver_init(DltReceiver *receiver, int _fd, DltReceiverType type, int _buffersize);
 /**
  * De-Initialize a dlt receiver structure
  * @param receiver pointer to dlt receiver structure
  * @return negative value if there was an error
  */
-DltReturnValue dlt_receiver_free(DltReceiver *receiver);
+DLT_EXPORT DltReturnValue dlt_receiver_free(DltReceiver *receiver);
 /**
  * Initialising a dlt receiver structure
  * @param receiver pointer to dlt receiver structure
@@ -1252,32 +1253,32 @@ DltReturnValue dlt_receiver_free(DltReceiver *receiver);
  * @param buffer data buffer for storing the received data
  * @return negative value if there was an error and zero if success
  */
-DltReturnValue dlt_receiver_init_global_buffer(DltReceiver *receiver, int fd, DltReceiverType type, char **buffer);
+DLT_EXPORT DltReturnValue dlt_receiver_init_global_buffer(DltReceiver *receiver, int fd, DltReceiverType type, char **buffer);
 /**
  * De-Initialize a dlt receiver structure
  * @param receiver pointer to dlt receiver structure
  * @return negative value if there was an error and zero if success
  */
-DltReturnValue dlt_receiver_free_global_buffer(DltReceiver *receiver);
+DLT_EXPORT DltReturnValue dlt_receiver_free_global_buffer(DltReceiver *receiver);
 /**
  * Receive data from socket or file/fifo using the dlt receiver structure
  * @param receiver pointer to dlt receiver structure
  * @return number of received bytes or negative value if there was an error
  */
-int dlt_receiver_receive(DltReceiver *receiver);
+DLT_EXPORT int dlt_receiver_receive(DltReceiver *receiver);
 /**
  * Remove a specific size of bytes from the received data
  * @param receiver pointer to dlt receiver structure
  * @param size amount of bytes to be removed
  * @return negative value if there was an error
  */
-DltReturnValue dlt_receiver_remove(DltReceiver *receiver, int size);
+DLT_EXPORT DltReturnValue dlt_receiver_remove(DltReceiver *receiver, int size);
 /**
  * Move data from last receive call to front of receive buffer
  * @param receiver pointer to dlt receiver structure
  * @return negative value if there was an error
  */
-DltReturnValue dlt_receiver_move_to_begin(DltReceiver *receiver);
+DLT_EXPORT DltReturnValue dlt_receiver_move_to_begin(DltReceiver *receiver);
 
 /**
  * Check whether to_get amount of data is available in receiver and
@@ -1287,7 +1288,7 @@ DltReturnValue dlt_receiver_move_to_begin(DltReceiver *receiver);
  * @param to_get size of the data to copy in dest
  * @param skip_header whether if the DltUserHeader must be skipped.
  */
-int dlt_receiver_check_and_get(DltReceiver *receiver,
+DLT_EXPORT int dlt_receiver_check_and_get(DltReceiver *receiver,
                                void *dest,
                                unsigned int to_get,
                                unsigned int skip_header);
@@ -1298,13 +1299,13 @@ int dlt_receiver_check_and_get(DltReceiver *receiver,
  * @param ecu name of ecu to be set in storage header
  * @return negative value if there was an error
  */
-DltReturnValue dlt_set_storageheader(DltStorageHeader *storageheader, const char *ecu);
+DLT_EXPORT DltReturnValue dlt_set_storageheader(DltStorageHeader *storageheader, const char *ecu);
 /**
  * Check if a storage header contains its marker
  * @param storageheader pointer to storage header of a dlt message
  * @return 0 no, 1 yes, negative value if there was an error
  */
-DltReturnValue dlt_check_storageheader(DltStorageHeader *storageheader);
+DLT_EXPORT DltReturnValue dlt_check_storageheader(DltStorageHeader *storageheader);
 
 /**
  * Checks if received size is big enough for expected data
@@ -1312,7 +1313,7 @@ DltReturnValue dlt_check_storageheader(DltStorageHeader *storageheader);
  * @param required size
  * @return negative value if required size is not sufficient
  * */
-DltReturnValue dlt_check_rcv_data_size(int received, int required);
+DLT_EXPORT DltReturnValue dlt_check_rcv_data_size(int received, int required);
 
 /**
  * Initialise static ringbuffer with a size of size.
@@ -1323,7 +1324,7 @@ DltReturnValue dlt_check_rcv_data_size(int received, int required);
  * @param size Maximum size of buffer in bytes
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_init_static_server(DltBuffer *buf, const unsigned char *ptr, uint32_t size);
+DLT_EXPORT DltReturnValue dlt_buffer_init_static_server(DltBuffer *buf, const unsigned char *ptr, uint32_t size);
 
 /**
  * Initialize static ringbuffer with a size of size.
@@ -1334,7 +1335,7 @@ DltReturnValue dlt_buffer_init_static_server(DltBuffer *buf, const unsigned char
  * @param size Maximum size of buffer in bytes
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_init_static_client(DltBuffer *buf, const unsigned char *ptr, uint32_t size);
+DLT_EXPORT DltReturnValue dlt_buffer_init_static_client(DltBuffer *buf, const unsigned char *ptr, uint32_t size);
 
 /**
  * Initialize dynamic ringbuffer with a size of size.
@@ -1348,21 +1349,21 @@ DltReturnValue dlt_buffer_init_static_client(DltBuffer *buf, const unsigned char
  * @param step_size size of which ringbuffer is increased
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_init_dynamic(DltBuffer *buf, uint32_t min_size, uint32_t max_size, uint32_t step_size);
+DLT_EXPORT DltReturnValue dlt_buffer_init_dynamic(DltBuffer *buf, uint32_t min_size, uint32_t max_size, uint32_t step_size);
 
 /**
  * Deinitilaise usage of static ringbuffer
  * @param buf Pointer to ringbuffer structure
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_free_static(DltBuffer *buf);
+DLT_EXPORT DltReturnValue dlt_buffer_free_static(DltBuffer *buf);
 
 /**
  * Release and free memory used by dynamic ringbuffer
  * @param buf Pointer to ringbuffer structure
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_free_dynamic(DltBuffer *buf);
+DLT_EXPORT DltReturnValue dlt_buffer_free_dynamic(DltBuffer *buf);
 
 /**
  * Check if message fits into buffer.
@@ -1370,7 +1371,7 @@ DltReturnValue dlt_buffer_free_dynamic(DltBuffer *buf);
  * @param needed Needed size
  * @return DLT_RETURN_OK if enough space, DLT_RETURN_ERROR otherwise
  */
-DltReturnValue dlt_buffer_check_size(DltBuffer *buf, int needed);
+DLT_EXPORT DltReturnValue dlt_buffer_check_size(DltBuffer *buf, int needed);
 
 /**
  * Write one entry to ringbuffer
@@ -1379,7 +1380,7 @@ DltReturnValue dlt_buffer_check_size(DltBuffer *buf, int needed);
  * @param size Size of data in bytes to be written to ringbuffer
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_push(DltBuffer *buf, const unsigned char *data, unsigned int size);
+DLT_EXPORT DltReturnValue dlt_buffer_push(DltBuffer *buf, const unsigned char *data, unsigned int size);
 
 /**
  * Write up to three entries to ringbuffer.
@@ -1393,7 +1394,7 @@ DltReturnValue dlt_buffer_push(DltBuffer *buf, const unsigned char *data, unsign
  * @param size3 Size of data in bytes to be written to ringbuffer
  * @return negative value if there was an error
  */
-DltReturnValue dlt_buffer_push3(DltBuffer *buf,
+DLT_EXPORT DltReturnValue dlt_buffer_push3(DltBuffer *buf,
                                 const unsigned char *data1,
                                 unsigned int size1,
                                 const unsigned char *data2,
@@ -1409,7 +1410,7 @@ DltReturnValue dlt_buffer_push3(DltBuffer *buf,
  * @param max_size Max size of read data in bytes from ringbuffer
  * @return size of read data, zero if no data available, negative value if there was an error
  */
-int dlt_buffer_pull(DltBuffer *buf, unsigned char *data, int max_size);
+DLT_EXPORT int dlt_buffer_pull(DltBuffer *buf, unsigned char *data, int max_size);
 
 /**
  * Read one entry from ringbuffer.
@@ -1419,26 +1420,26 @@ int dlt_buffer_pull(DltBuffer *buf, unsigned char *data, int max_size);
  * @param max_size Max size of read data in bytes from ringbuffer
  * @return size of read data, zero if no data available, negative value if there was an error
  */
-int dlt_buffer_copy(DltBuffer *buf, unsigned char *data, int max_size);
+DLT_EXPORT int dlt_buffer_copy(DltBuffer *buf, unsigned char *data, int max_size);
 
 /**
  * Remove entry from ringbuffer.
  * @param buf Pointer to ringbuffer structure
  * @return size of read data, zero if no data available, negative value if there was an error
  */
-int dlt_buffer_remove(DltBuffer *buf);
+DLT_EXPORT int dlt_buffer_remove(DltBuffer *buf);
 
 /**
  * Print information about buffer and log to internal DLT log.
  * @param buf Pointer to ringbuffer structure
  */
-void dlt_buffer_info(DltBuffer *buf);
+DLT_EXPORT void dlt_buffer_info(DltBuffer *buf);
 
 /**
  * Print status of buffer and log to internal DLT log.
  * @param buf Pointer to ringbuffer structure
  */
-void dlt_buffer_status(DltBuffer *buf);
+DLT_EXPORT void dlt_buffer_status(DltBuffer *buf);
 
 /**
  * Get total size in bytes of ringbuffer.
@@ -1446,21 +1447,21 @@ void dlt_buffer_status(DltBuffer *buf);
  * @param buf Pointer to ringbuffer structure
  * @return total size of buffer
  */
-uint32_t dlt_buffer_get_total_size(DltBuffer *buf);
+DLT_EXPORT uint32_t dlt_buffer_get_total_size(DltBuffer *buf);
 
 /**
  * Get used size in bytes of ringbuffer.
  * @param buf Pointer to ringbuffer structure
  * @return used size of buffer
  */
-int dlt_buffer_get_used_size(DltBuffer *buf);
+DLT_EXPORT int dlt_buffer_get_used_size(DltBuffer *buf);
 
 /**
  * Get number of entries in ringbuffer.
  * @param buf Pointer to ringbuffer structure
  * @return number of entries
  */
-int dlt_buffer_get_message_count(DltBuffer *buf);
+DLT_EXPORT int dlt_buffer_get_message_count(DltBuffer *buf);
 
 #   if !defined (__WIN32__)
 
@@ -1470,35 +1471,35 @@ int dlt_buffer_get_message_count(DltBuffer *buf);
  * @param speed Serial line speed, as defined in termios.h
  * @return negative value if there was an error
  */
-DltReturnValue dlt_setup_serial(int fd, speed_t speed);
+DLT_EXPORT DltReturnValue dlt_setup_serial(int fd, speed_t speed);
 
 /**
  * Helper function: Convert serial line baudrate (as number) to line speed (as defined in termios.h)
  * @param baudrate Serial line baudrate (as number)
  * @return Serial line speed, as defined in termios.h
  */
-speed_t dlt_convert_serial_speed(int baudrate);
+DLT_EXPORT speed_t dlt_convert_serial_speed(int baudrate);
 
 /**
  * Print dlt version and dlt svn version to buffer
  * @param buf Pointer to buffer
  * @param size size of buffer
  */
-void dlt_get_version(char *buf, size_t size);
+DLT_EXPORT void dlt_get_version(char *buf, size_t size);
 
 /**
  * Print dlt major version to buffer
  * @param buf Pointer to buffer
  * @param size size of buffer
  */
-void dlt_get_major_version(char *buf, size_t size);
+DLT_EXPORT void dlt_get_major_version(char *buf, size_t size);
 
 /**
  * Print dlt minor version to buffer
  * @param buf Pointer to buffer
  * @param size size of buffer
  */
-void dlt_get_minor_version(char *buf, size_t size);
+DLT_EXPORT void dlt_get_minor_version(char *buf, size_t size);
 
 #   endif
 
@@ -1519,13 +1520,13 @@ void dlt_get_minor_version(char *buf, size_t size);
  * - DLT_DISABLE_INJECTION_MSG_AT_USER
  * @return negative value if there was an error
  */
-DltReturnValue dlt_init_common(void);
+DLT_EXPORT DltReturnValue dlt_init_common(void);
 
 /**
  * Return the uptime of the system in 0.1 ms resolution
  * @return 0 if there was an error
  */
-uint32_t dlt_uptime(void);
+DLT_EXPORT uint32_t dlt_uptime(void);
 
 /**
  * Print header of a DLT message
@@ -1535,7 +1536,7 @@ uint32_t dlt_uptime(void);
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_print_header(DltMessage *message, char *text, uint32_t size, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_print_header(DltMessage *message, char *text, uint32_t size, int verbose);
 
 /**
  * Print payload of a DLT message as Hex-Output
@@ -1545,7 +1546,7 @@ DltReturnValue dlt_message_print_header(DltMessage *message, char *text, uint32_
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_print_hex(DltMessage *message, char *text, uint32_t size, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_print_hex(DltMessage *message, char *text, uint32_t size, int verbose);
 
 /**
  * Print payload of a DLT message as ASCII-Output
@@ -1555,7 +1556,7 @@ DltReturnValue dlt_message_print_hex(DltMessage *message, char *text, uint32_t s
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_print_ascii(DltMessage *message, char *text, uint32_t size, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_print_ascii(DltMessage *message, char *text, uint32_t size, int verbose);
 
 /**
  * Print payload of a DLT message as Mixed-Ouput (Hex and ASCII), for plain text output
@@ -1565,7 +1566,7 @@ DltReturnValue dlt_message_print_ascii(DltMessage *message, char *text, uint32_t
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_print_mixed_plain(DltMessage *message, char *text, uint32_t size, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_print_mixed_plain(DltMessage *message, char *text, uint32_t size, int verbose);
 
 /**
  * Print payload of a DLT message as Mixed-Ouput (Hex and ASCII), for HTML text output
@@ -1575,7 +1576,7 @@ DltReturnValue dlt_message_print_mixed_plain(DltMessage *message, char *text, ui
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_print_mixed_html(DltMessage *message, char *text, uint32_t size, int verbose);
+DLT_EXPORT DltReturnValue dlt_message_print_mixed_html(DltMessage *message, char *text, uint32_t size, int verbose);
 
 /**
  * Decode and print a argument of a DLT message
@@ -1589,7 +1590,7 @@ DltReturnValue dlt_message_print_mixed_html(DltMessage *message, char *text, uin
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-DltReturnValue dlt_message_argument_print(DltMessage *msg,
+DLT_EXPORT DltReturnValue dlt_message_argument_print(DltMessage *msg,
                                           uint32_t type_info,
                                           uint8_t **ptr,
                                           int32_t *datalength,
@@ -1601,7 +1602,7 @@ DltReturnValue dlt_message_argument_print(DltMessage *msg,
 /**
  * Check environment variables.
  */
-void dlt_check_envvar(void);
+DLT_EXPORT void dlt_check_envvar(void);
 
 /**
  * Parse the response text and identifying service id and its options.
@@ -1611,7 +1612,7 @@ void dlt_check_envvar(void);
  * @param service_opt int *
  * @return pointer to resp_text
  */
-int dlt_set_loginfo_parse_service_id(char *resp_text, uint32_t *service_id, uint8_t *service_opt);
+DLT_EXPORT int dlt_set_loginfo_parse_service_id(char *resp_text, uint32_t *service_id, uint8_t *service_opt);
 
 /**
  * Convert get log info from ASCII to uint16
@@ -1620,7 +1621,7 @@ int dlt_set_loginfo_parse_service_id(char *resp_text, uint32_t *service_id, uint
  * @param rp_count  int
  * @return length
  */
-int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count);
+DLT_EXPORT int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count);
 
 /**
  * Convert get log info from ASCII to int16
@@ -1629,7 +1630,7 @@ int16_t dlt_getloginfo_conv_ascii_to_uint16_t(char *rp, int *rp_count);
  * @param rp_count  int
  * @return length
  */
-int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count);
+DLT_EXPORT int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count);
 
 
 /**
@@ -1640,7 +1641,7 @@ int16_t dlt_getloginfo_conv_ascii_to_int16_t(char *rp, int *rp_count);
  * @param wp        char Array needs to be 1 byte larger than len to store '\0'
  * @param len       int
  */
-void dlt_getloginfo_conv_ascii_to_string(char *rp, int *rp_count, char *wp, int len);
+DLT_EXPORT void dlt_getloginfo_conv_ascii_to_string(char *rp, int *rp_count, char *wp, int len);
 
 
 /**
@@ -1652,7 +1653,7 @@ void dlt_getloginfo_conv_ascii_to_string(char *rp, int *rp_count, char *wp, int 
  * @param len       int
  * @return position of last read character in wp
  */
-int dlt_getloginfo_conv_ascii_to_id(char *rp, int *rp_count, char *wp, int len);
+DLT_EXPORT int dlt_getloginfo_conv_ascii_to_id(char *rp, int *rp_count, char *wp, int len);
 
 /**
  * Convert from hex ASCII to binary
@@ -1660,7 +1661,7 @@ int dlt_getloginfo_conv_ascii_to_id(char *rp, int *rp_count, char *wp, int len);
  * @param binary uint8_t
  * @param size   int
  */
-void dlt_hex_ascii_to_binary(const char *ptr, uint8_t *binary, int *size);
+DLT_EXPORT void dlt_hex_ascii_to_binary(const char *ptr, uint8_t *binary, int *size);
 
 /**
  * Helper function to execute the execvp function in a new child process.
@@ -1668,14 +1669,14 @@ void dlt_hex_ascii_to_binary(const char *ptr, uint8_t *binary, int *size);
  * @param command execution command followed by arguments with NULL-termination
  * @return negative value if there was an error
  */
-int dlt_execute_command(char *filename, char *command, ...);
+DLT_EXPORT int dlt_execute_command(char *filename, char *command, ...);
 
 /**
  * Return the extension of given file name.
  * @param filename Only file names without prepended path allowed.
  * @return pointer to extension
  */
-char *get_filename_ext(const char *filename);
+DLT_EXPORT char *get_filename_ext(const char *filename);
 
 /**
  * Extract the base name of given file name (without the extension).
@@ -1684,7 +1685,7 @@ char *get_filename_ext(const char *filename);
  * @param base_name_length Base name length.
  * @return indicating success
  */
-bool dlt_extract_base_name_without_ext(const char* const abs_file_name, char* base_name, long base_name_len);
+DLT_EXPORT bool dlt_extract_base_name_without_ext(const char* const abs_file_name, char* base_name, long base_name_len);
 
 /**
  * Initialize (external) logging facility
@@ -1693,33 +1694,33 @@ bool dlt_extract_base_name_without_ext(const char* const abs_file_name, char* ba
  * @param logging_file_size, maximum size in bytes of one logging file
  * @param logging_files_max_size, maximum size in bytes of all logging files
  */
-DltReturnValue dlt_log_init_multiple_logfiles_support(DltLoggingMode mode, bool enable_multiple_logfiles, int logging_file_size, int logging_files_max_size);
+DLT_EXPORT DltReturnValue dlt_log_init_multiple_logfiles_support(DltLoggingMode mode, bool enable_multiple_logfiles, int logging_file_size, int logging_files_max_size);
 
 /**
  * Initialize (external) logging facility for single logfile.
  */
-DltReturnValue dlt_log_init_single_logfile();
+DLT_EXPORT DltReturnValue dlt_log_init_single_logfile();
 
 /**
  * Initialize (external) logging facility for multiple files logging.
  */
-DltReturnValue dlt_log_init_multiple_logfiles(int logging_file_size, int logging_files_max_size);
+DLT_EXPORT DltReturnValue dlt_log_init_multiple_logfiles(int logging_file_size, int logging_files_max_size);
 
 /**
  * Logs into log files represented by the multiple files buffer.
  * @param format First element in a specific format that will be logged.
  * @param ... Further elements in a specific format that will be logged.
  */
-void dlt_log_multiple_files_write(const char* format, ...);
+DLT_EXPORT void dlt_log_multiple_files_write(const char* format, ...);
 
-void dlt_log_free_single_logfile();
+DLT_EXPORT void dlt_log_free_single_logfile();
 
-void dlt_log_free_multiple_logfiles();
+DLT_EXPORT void dlt_log_free_multiple_logfiles();
 
 /**
  * Checks whether (internal) logging in multiple files is active.
  */
-bool dlt_is_log_in_multiple_files_active();
+DLT_EXPORT bool dlt_is_log_in_multiple_files_active();
 
 #   ifdef __cplusplus
 }

--- a/include/dlt/dlt_cpp_extension.hpp
+++ b/include/dlt/dlt_cpp_extension.hpp
@@ -33,7 +33,7 @@
 #include "dlt.h"
 
 template<typename T>
-int32_t logToDlt(DltContextData &log, T const &value) = delete;
+static int32_t logToDlt(DltContextData &log, T const &value) = delete;
 
 template<>
 inline int32_t logToDlt(DltContextData &log, int8_t const &value)
@@ -65,38 +65,32 @@ inline int32_t logToDlt(DltContextData &log, uint8_t const &value)
     return dlt_user_log_write_uint8(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, uint16_t const &value)
+template <> inline int32_t logToDlt(DltContextData &log, uint16_t const &value)
 {
     return dlt_user_log_write_uint16(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, uint32_t const &value)
+template <> inline int32_t logToDlt(DltContextData &log, uint32_t const &value)
 {
     return dlt_user_log_write_uint32(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, uint64_t const &value)
+template <> inline int32_t logToDlt(DltContextData &log, uint64_t const &value)
 {
     return dlt_user_log_write_uint64(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, float32_t const &value)
+template <> inline int32_t logToDlt(DltContextData &log, float32_t const &value)
 {
     return dlt_user_log_write_float32(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, double const &value)
+template <> inline int32_t logToDlt(DltContextData &log, double const &value)
 {
     return dlt_user_log_write_float64(&log, value);
 }
 
-template<>
-inline int32_t logToDlt(DltContextData &log, bool const &value)
+template <> inline int32_t logToDlt(DltContextData &log, bool const &value)
 {
     return dlt_user_log_write_bool(&log, value);
 }
@@ -111,15 +105,12 @@ static inline int32_t logToDlt(DltContextData &log, char * const value)
     return dlt_user_log_write_utf8_string(&log, value);
 }
 
+/* stl types */
 template<>
 inline int32_t logToDlt(DltContextData &log, std::string const &value)
 {
     return dlt_user_log_write_utf8_string(&log, value.c_str());
 }
-
-/* stl types */
-template<>
-int32_t logToDlt(DltContextData &log, std::string const &value);
 
 template<typename _Tp, typename _Alloc = std::allocator<_Tp>>
 static inline int32_t logToDlt(DltContextData &log, std::vector<_Tp, _Alloc> const & value)

--- a/include/dlt/dlt_filetransfer.h
+++ b/include/dlt/dlt_filetransfer.h
@@ -31,6 +31,7 @@
 #include <signal.h>    /* Signal handling */
 #include "errno.h"
 
+#include "dlt_export.h"
 
 /* ! Error code for dlt_user_log_file_complete */
 #define DLT_FILETRANSFER_ERROR_FILE_COMPLETE -300
@@ -68,7 +69,7 @@
  * @param timeout Timeout in ms to wait between some logs. Important that the FIFO of dlt will not be flooded with to many messages in a short period of time.
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_complete(DltContext *fileContext, const char *filename, int deleteFlag, int timeout);
+DLT_EXPORT int dlt_user_log_file_complete(DltContext *fileContext, const char *filename, int deleteFlag, int timeout);
 
 
 /* !This method gives information about the number of packages the file have */
@@ -80,7 +81,7 @@ extern int dlt_user_log_file_complete(DltContext *fileContext, const char *filen
  * @param filename Absolute file path
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_packagesCount(DltContext *fileContext, const char *filename);
+DLT_EXPORT int dlt_user_log_file_packagesCount(DltContext *fileContext, const char *filename);
 
 
 /* !Logs specific file inforamtions to dlt */
@@ -89,7 +90,7 @@ extern int dlt_user_log_file_packagesCount(DltContext *fileContext, const char *
  * @param filename Absolute file path
  * @return Returns 0 if everything was okey.If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_infoAbout(DltContext *fileContext, const char *filename);
+DLT_EXPORT int dlt_user_log_file_infoAbout(DltContext *fileContext, const char *filename);
 
 
 /* !Transfer the head of the file as a dlt logs. */
@@ -102,7 +103,7 @@ extern int dlt_user_log_file_infoAbout(DltContext *fileContext, const char *file
  * @param alias Alias for the file. An alternative name to show in the receiving end
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_header_alias(DltContext *fileContext, const char *filename, const char *alias);
+DLT_EXPORT int dlt_user_log_file_header_alias(DltContext *fileContext, const char *filename, const char *alias);
 
 /* !Transfer the head of the file as a dlt logs. */
 /**The head of the file must be logged to dlt because the head contains inforamtion about the file serial number,
@@ -113,7 +114,7 @@ extern int dlt_user_log_file_header_alias(DltContext *fileContext, const char *f
  * @param filename Absolute file path
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_header(DltContext *fileContext, const char *filename);
+DLT_EXPORT int dlt_user_log_file_header(DltContext *fileContext, const char *filename);
 
 
 /* !Transfer the content data of a file. */
@@ -124,7 +125,7 @@ extern int dlt_user_log_file_header(DltContext *fileContext, const char *filenam
  * @param timeout Timeout to wait between dlt logs. Important because the dlt FIFO should not be flooded. Default is defined by MIN_TIMEOUT. The given timeout in ms can not be smaller than MIN_TIMEOUT.
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_data(DltContext *fileContext, const char *filename, int packageToTransfer, int timeout);
+DLT_EXPORT int dlt_user_log_file_data(DltContext *fileContext, const char *filename, int packageToTransfer, int timeout);
 
 
 
@@ -137,6 +138,6 @@ extern int dlt_user_log_file_data(DltContext *fileContext, const char *filename,
  * @param deleteFlag Flag to delete the file after the whole file is transferred (logged to dlt).1->delete,0->NotDelete
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
-extern int dlt_user_log_file_end(DltContext *fileContext, const char *filename, int deleteFlag);
+DLT_EXPORT int dlt_user_log_file_end(DltContext *fileContext, const char *filename, int deleteFlag);
 
 #endif /* DLT_FILETRANSFER_H */

--- a/include/dlt/dlt_multiple_files.h
+++ b/include/dlt/dlt_multiple_files.h
@@ -31,6 +31,7 @@
 #include <limits.h>
 
 #include "dlt_common.h"
+#include "dlt_export.h"
 #include "dlt_types.h"
 
 #define MULTIPLE_FILES_FILENAME_INDEX_DELIM "."
@@ -69,14 +70,10 @@ typedef struct
  * @param filename_ext File extension.
  * @return negative value if there was an error.
  */
-extern DltReturnValue multiple_files_buffer_init(MultipleFilesRingBuffer *files_buffer,
-                                                 const char *directory,
-                                                 int file_size,
-                                                 int max_size,
-                                                 bool filename_timestamp_based,
-                                                 bool append,
-                                                 const char *filename_base,
-                                                 const char *filename_ext);
+DLT_EXPORT DltReturnValue multiple_files_buffer_init(
+    MultipleFilesRingBuffer *files_buffer, const char *directory, int file_size,
+    int max_size, bool filename_timestamp_based, bool append,
+    const char *filename_base, const char *filename_ext);
 
 /**
  * Uninitialise the multiple files buffer.
@@ -85,7 +82,8 @@ extern DltReturnValue multiple_files_buffer_init(MultipleFilesRingBuffer *files_
  * @param files_buffer pointer to MultipleFilesRingBuffer struct.
  * @return negative value if there was an error.
 */
-extern DltReturnValue multiple_files_buffer_free(const MultipleFilesRingBuffer *files_buffer);
+DLT_EXPORT DltReturnValue
+multiple_files_buffer_free(const MultipleFilesRingBuffer *files_buffer);
 
 /**
  * Write data into multiple files.
@@ -97,17 +95,17 @@ extern DltReturnValue multiple_files_buffer_free(const MultipleFilesRingBuffer *
  * @param size size in bytes of first data block to be written, 0 if not used.
  * @return negative value if there was an error.
  */
-extern DltReturnValue multiple_files_buffer_write(MultipleFilesRingBuffer *files_buffer,
-                                                  const unsigned char *data,
-                                                  int size);
+DLT_EXPORT DltReturnValue multiple_files_buffer_write(
+    MultipleFilesRingBuffer *files_buffer, const unsigned char *data, int size);
 
 /**
  * First the limits are verified. Then the oldest file is deleted and a new file is created on demand.
  * @param files_buffer pointer to MultipleFilesRingBuffer struct.
  * @param size size in bytes of data that will be written.
  */
-void multiple_files_buffer_rotate_file(MultipleFilesRingBuffer *files_buffer,
-                                       int size);
+DLT_EXPORT void
+multiple_files_buffer_rotate_file(MultipleFilesRingBuffer *files_buffer,
+                                  int size);
 
 /**
  * Writes the given data to current file specified by corresponding file handle.
@@ -115,15 +113,16 @@ void multiple_files_buffer_rotate_file(MultipleFilesRingBuffer *files_buffer,
  * @param data pointer to data block to be written, null if not used.
  * @param size size in bytes of given data block to be written, 0 if not used.
  */
-DltReturnValue multiple_files_buffer_write_chunk(const MultipleFilesRingBuffer *files_buffer,
-                                                 const unsigned char *data,
-                                                 int size);
+DLT_EXPORT DltReturnValue
+multiple_files_buffer_write_chunk(const MultipleFilesRingBuffer *files_buffer,
+                                  const unsigned char *data, int size);
 
 /**
  * Get size of currently used multiple files buffer.
  * @return size in bytes.
  */
-extern ssize_t multiple_files_buffer_get_total_size(const MultipleFilesRingBuffer *files_buffer);
+DLT_EXPORT ssize_t multiple_files_buffer_get_total_size(
+    const MultipleFilesRingBuffer *files_buffer);
 
 /**
  * Provides info about the multiple files storage directory.
@@ -133,8 +132,9 @@ extern ssize_t multiple_files_buffer_get_total_size(const MultipleFilesRingBuffe
  * @param oldest pointer to store oldest filename
  * @return num of files in the directory.
  */
-unsigned int multiple_files_buffer_storage_dir_info(const char *path, const char *file_name,
-                                                    char *newest, char *oldest);
+DLT_EXPORT unsigned int
+multiple_files_buffer_storage_dir_info(const char *path, const char *file_name,
+                                       char *newest, char *oldest);
 
 /**
  * Creates filename with index.
@@ -142,13 +142,15 @@ unsigned int multiple_files_buffer_storage_dir_info(const char *path, const char
  * @param length the maximum length of the log_file_name.
  * @param idx index to be used for file name creation.
  */
-void multiple_files_buffer_file_name(MultipleFilesRingBuffer *files_buffer, size_t length, unsigned int idx);
+DLT_EXPORT void
+multiple_files_buffer_file_name(MultipleFilesRingBuffer *files_buffer,
+                                size_t length, unsigned int idx);
 
 /**
  * Generates index for log file name.
  * @param file filename supplied to create index.
  * @return the index to be used for log file name.
  */
-unsigned int multiple_files_buffer_get_idx_of_log_file(char *file);
+DLT_EXPORT unsigned int multiple_files_buffer_get_idx_of_log_file(char *file);
 
 #endif // DLT_MULTIPLE_FILES_H

--- a/include/dlt/dlt_offline_trace.h
+++ b/include/dlt/dlt_offline_trace.h
@@ -57,6 +57,7 @@
 
 #include <limits.h>
 
+#include "dlt_export.h"
 #include "dlt_multiple_files.h"
 #include "dlt_types.h"
 
@@ -77,7 +78,7 @@
  * @param size3 size in bytes of third data block to be written, 0 if not used.
  * @return negative value if there was an error.
  */
-extern DltReturnValue dlt_offline_trace_write(MultipleFilesRingBuffer *trace,
+DLT_EXPORT DltReturnValue dlt_offline_trace_write(MultipleFilesRingBuffer *trace,
                                               const unsigned char *data1,
                                               int size1,
                                               const unsigned char *data2,

--- a/include/dlt/dlt_shm.h
+++ b/include/dlt/dlt_shm.h
@@ -89,7 +89,7 @@ typedef struct
  * @param name the name of the shm, must be the same for server and client
  * @return negative value if there was an error
  */
-extern DltReturnValue dlt_shm_init_client(DltShm *buf, const char *name);
+DLT_EXPORT DltReturnValue dlt_shm_init_client(DltShm *buf, const char *name);
 
 /**
  * Initialise the shared memory on the server side.
@@ -99,7 +99,7 @@ extern DltReturnValue dlt_shm_init_client(DltShm *buf, const char *name);
  * @param size the requested size of the shm
  * @return negative value if there was an error
  */
-extern DltReturnValue dlt_shm_init_server(DltShm *buf, const char *name, int size);
+DLT_EXPORT DltReturnValue dlt_shm_init_server(DltShm *buf, const char *name, int size);
 
 /**
  * Push data from client onto the shm.
@@ -112,7 +112,7 @@ extern DltReturnValue dlt_shm_init_server(DltShm *buf, const char *name, int siz
  * @param size3 size in bytes of third data block to be written, 0 if not used
  * @return negative value if there was an error
  */
-extern int dlt_shm_push(DltShm *buf,
+DLT_EXPORT int dlt_shm_push(DltShm *buf,
                         const unsigned char *data1,
                         unsigned int size1,
                         const unsigned char *data2,
@@ -129,7 +129,7 @@ extern int dlt_shm_push(DltShm *buf,
  * @param size maximum size to be written into buffer
  * @return negative value if there was an error
  */
-extern int dlt_shm_pull(DltShm *buf, unsigned char *data, int size);
+DLT_EXPORT int dlt_shm_pull(DltShm *buf, unsigned char *data, int size);
 
 /**
  * Copy message from shm.
@@ -140,7 +140,7 @@ extern int dlt_shm_pull(DltShm *buf, unsigned char *data, int size);
  * @param size maximum size to be written into buffer
  * @return negative value if there was an error
  */
-extern int dlt_shm_copy(DltShm *buf, unsigned char *data, int size);
+DLT_EXPORT int dlt_shm_copy(DltShm *buf, unsigned char *data, int size);
 
 /**
  * Delete message from shm.
@@ -149,61 +149,61 @@ extern int dlt_shm_copy(DltShm *buf, unsigned char *data, int size);
  * @param buf pointer to shm structure
  * @return negative value if there was an error
  */
-extern int dlt_shm_remove(DltShm *buf);
+DLT_EXPORT int dlt_shm_remove(DltShm *buf);
 
 /**
  * Print information about shm.
  * @param buf pointer to shm structure
  */
-extern void dlt_shm_info(DltShm *buf);
+DLT_EXPORT void dlt_shm_info(DltShm *buf);
 
 /**
  * Print status about shm.
  * @param buf pointer to shm structure
  */
-extern void dlt_shm_status(DltShm *buf);
+DLT_EXPORT void dlt_shm_status(DltShm *buf);
 
 /**
  * Deinitialise the shared memory on the client side.
  * @param buf pointer to shm structure
  * @return negative value if there was an error
  */
-extern DltReturnValue dlt_shm_free_client(DltShm *buf);
+DLT_EXPORT DltReturnValue dlt_shm_free_client(DltShm *buf);
 
 /**
  * Returns the total size of the shm.
  * @param buf pointer to shm structure
  * @return size of the shared memory.
  */
-extern int dlt_shm_get_total_size(DltShm *buf);
+DLT_EXPORT int dlt_shm_get_total_size(DltShm *buf);
 
 /**
  * Returns the used size in the shm.
  * @param buf pointer to shm structure
  * @return size of the shared memory.
  */
-extern int dlt_shm_get_used_size(DltShm *buf);
+DLT_EXPORT int dlt_shm_get_used_size(DltShm *buf);
 
 /**
  * Returns the number of messages in the shm.
  * @param buf pointer to shm structure
  * @return size of the shared memory.
  */
-extern int dlt_shm_get_message_count(DltShm *buf);
+DLT_EXPORT int dlt_shm_get_message_count(DltShm *buf);
 
 /**
  * Reset pointers and counters when shm corrupted.
  * @param buf pointer to shm structure
  * @return size of the shared memory.
  */
-extern int dlt_shm_reset(DltShm *buf);
+DLT_EXPORT int dlt_shm_reset(DltShm *buf);
 
 /**
  * Recover to find next valid message.
  * @param buf pointer to shm structure
  * @return size of the shared memory.
  */
-extern int dlt_shm_recover(DltShm *buf);
+DLT_EXPORT int dlt_shm_recover(DltShm *buf);
 
 /**
  * Deinitialise the shared memory on the server side.
@@ -211,6 +211,6 @@ extern int dlt_shm_recover(DltShm *buf);
  * @param name name of the shared memory
  * @return negative value if there was an error
  */
-extern DltReturnValue dlt_shm_free_server(DltShm *buf, const char *name);
+DLT_EXPORT DltReturnValue dlt_shm_free_server(DltShm *buf, const char *name);
 
 #endif /* DLT_SHM_H */

--- a/include/dlt/dlt_user.h.in
+++ b/include/dlt/dlt_user.h.in
@@ -95,6 +95,7 @@
 #      include <semaphore.h>
 #   endif
 
+#   include "dlt_export.h"
 #   include "dlt_types.h"
 #   include "dlt_shm.h"
 #if !DLT_DISABLE_MACRO
@@ -285,7 +286,7 @@ typedef int (*dlt_injection_callback)(uint32_t, void *, uint32_t);
  * @param loglevel this is the current log level of the log message to be sent
  * @return Value from DltReturnValue enum, DLT_RETURN_TRUE if log level is matching
  */
-DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log, DltLogLevelType loglevel);
+DLT_EXPORT DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log, DltLogLevelType loglevel);
 
 /**
  * Initialize the generation of a DLT log message (intended for usage in non-verbose mode)
@@ -298,7 +299,7 @@ DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log,
  * @param messageid message id of message
  * @return Value from DltReturnValue enum, DLT_RETURN_TRUE if log level is matching
  */
-DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
                                            DltContextData *log,
                                            DltLogLevelType loglevel,
                                            uint32_t messageid);
@@ -320,7 +321,7 @@ DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
  * @param args_num number of arguments in buffer
  * @return Value from DltReturnValue enum, DLT_RETURN_TRUE if log level is matching
  */
-DltReturnValue dlt_user_log_write_start_w_given_buffer(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_user_log_write_start_w_given_buffer(DltContext *handle,
                                                        DltContextData *log,
                                                        DltLogLevelType loglevel,
                                                        char *buffer,
@@ -333,7 +334,7 @@ DltReturnValue dlt_user_log_write_start_w_given_buffer(DltContext *handle,
  * @param log pointer to an object containing information about logging context data
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_finish(DltContextData *log);
+DLT_EXPORT DltReturnValue dlt_user_log_write_finish(DltContextData *log);
 
 /**
  * Finishing the generation of a DLT log message and sending it to the DLT daemon without
@@ -343,7 +344,7 @@ DltReturnValue dlt_user_log_write_finish(DltContextData *log);
  * @param log pointer to an object containing information about logging context data
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_finish_w_given_buffer(DltContextData *log);
+DLT_EXPORT DltReturnValue dlt_user_log_write_finish_w_given_buffer(DltContextData *log);
 
 /**
  * Write a boolean parameter into a DLT log message.
@@ -353,7 +354,7 @@ DltReturnValue dlt_user_log_write_finish_w_given_buffer(DltContextData *log);
  * @param data boolean parameter written into log message (mapped to uint8)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_bool(DltContextData *log, uint8_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_bool(DltContextData *log, uint8_t data);
 
 /**
  * Write a boolean parameter with "name" attribute into a DLT log message.
@@ -368,7 +369,7 @@ DltReturnValue dlt_user_log_write_bool(DltContextData *log, uint8_t data);
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_bool_attr(DltContextData *log, uint8_t data, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_bool_attr(DltContextData *log, uint8_t data, const char *name);
 
 /**
  * Write a float parameter into a DLT log message.
@@ -378,7 +379,7 @@ DltReturnValue dlt_user_log_write_bool_attr(DltContextData *log, uint8_t data, c
  * @param data float32_t parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_float32(DltContextData *log, float32_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_float32(DltContextData *log, float32_t data);
 
 /**
  * Write a double parameter into a DLT log message.
@@ -388,7 +389,7 @@ DltReturnValue dlt_user_log_write_float32(DltContextData *log, float32_t data);
  * @param data float64_t parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_float64(DltContextData *log, double data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_float64(DltContextData *log, double data);
 
 /**
  * Write a float parameter with attributes into a DLT log message.
@@ -404,7 +405,7 @@ DltReturnValue dlt_user_log_write_float64(DltContextData *log, double data);
  * @param unit  the "unit" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_float32_attr(DltContextData *log, float32_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_float32_attr(DltContextData *log, float32_t data, const char *name, const char *unit);
 
 /**
  * Write a double parameter with attributes into a DLT log message.
@@ -420,7 +421,7 @@ DltReturnValue dlt_user_log_write_float32_attr(DltContextData *log, float32_t da
  * @param unit  the "unit" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_float64_attr(DltContextData *log, float64_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_float64_attr(DltContextData *log, float64_t data, const char *name, const char *unit);
 
 /**
  * Write a uint parameter into a DLT log message.
@@ -430,11 +431,11 @@ DltReturnValue dlt_user_log_write_float64_attr(DltContextData *log, float64_t da
  * @param data unsigned int parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_uint(DltContextData *log, unsigned int data);
-DltReturnValue dlt_user_log_write_uint8(DltContextData *log, uint8_t data);
-DltReturnValue dlt_user_log_write_uint16(DltContextData *log, uint16_t data);
-DltReturnValue dlt_user_log_write_uint32(DltContextData *log, uint32_t data);
-DltReturnValue dlt_user_log_write_uint64(DltContextData *log, uint64_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint(DltContextData *log, unsigned int data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint8(DltContextData *log, uint8_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint16(DltContextData *log, uint16_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint32(DltContextData *log, uint32_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint64(DltContextData *log, uint64_t data);
 
 /**
  * Write a uint parameter with attributes into a DLT log message.
@@ -450,11 +451,11 @@ DltReturnValue dlt_user_log_write_uint64(DltContextData *log, uint64_t data);
  * @param unit  the "unit" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_uint_attr(DltContextData *log, unsigned int data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_uint8_attr(DltContextData *log, uint8_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_uint16_attr(DltContextData *log, uint16_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_uint32_attr(DltContextData *log, uint32_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_uint64_attr(DltContextData *log, uint64_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint_attr(DltContextData *log, unsigned int data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint8_attr(DltContextData *log, uint8_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint16_attr(DltContextData *log, uint16_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint32_attr(DltContextData *log, uint32_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint64_attr(DltContextData *log, uint64_t data, const char *name, const char *unit);
 
 /**
  * Write a uint parameter into a DLT log message. The output will be formatted as given by the parameter type.
@@ -465,10 +466,10 @@ DltReturnValue dlt_user_log_write_uint64_attr(DltContextData *log, uint64_t data
  * @param type The formatting type of the string output.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_uint8_formatted(DltContextData *log, uint8_t data, DltFormatType type);
-DltReturnValue dlt_user_log_write_uint16_formatted(DltContextData *log, uint16_t data, DltFormatType type);
-DltReturnValue dlt_user_log_write_uint32_formatted(DltContextData *log, uint32_t data, DltFormatType type);
-DltReturnValue dlt_user_log_write_uint64_formatted(DltContextData *log, uint64_t data, DltFormatType type);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint8_formatted(DltContextData *log, uint8_t data, DltFormatType type);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint16_formatted(DltContextData *log, uint16_t data, DltFormatType type);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint32_formatted(DltContextData *log, uint32_t data, DltFormatType type);
+DLT_EXPORT DltReturnValue dlt_user_log_write_uint64_formatted(DltContextData *log, uint64_t data, DltFormatType type);
 
 /**
  * Write a pointer value architecture independent.
@@ -478,7 +479,7 @@ DltReturnValue dlt_user_log_write_uint64_formatted(DltContextData *log, uint64_t
  * @param data void* parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_ptr(DltContextData *log, void *data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_ptr(DltContextData *log, void *data);
 
 /**
  * Write a int parameter into a DLT log message.
@@ -488,11 +489,11 @@ DltReturnValue dlt_user_log_write_ptr(DltContextData *log, void *data);
  * @param data int parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_int(DltContextData *log, int data);
-DltReturnValue dlt_user_log_write_int8(DltContextData *log, int8_t data);
-DltReturnValue dlt_user_log_write_int16(DltContextData *log, int16_t data);
-DltReturnValue dlt_user_log_write_int32(DltContextData *log, int32_t data);
-DltReturnValue dlt_user_log_write_int64(DltContextData *log, int64_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int(DltContextData *log, int data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int8(DltContextData *log, int8_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int16(DltContextData *log, int16_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int32(DltContextData *log, int32_t data);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int64(DltContextData *log, int64_t data);
 
 /**
  * Write an int parameter with attributes into a DLT log message.
@@ -508,11 +509,11 @@ DltReturnValue dlt_user_log_write_int64(DltContextData *log, int64_t data);
  * @param unit  the "unit" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_int_attr(DltContextData *log, int data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_int8_attr(DltContextData *log, int8_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_int16_attr(DltContextData *log, int16_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_int32_attr(DltContextData *log, int32_t data, const char *name, const char *unit);
-DltReturnValue dlt_user_log_write_int64_attr(DltContextData *log, int64_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int_attr(DltContextData *log, int data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int8_attr(DltContextData *log, int8_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int16_attr(DltContextData *log, int16_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int32_attr(DltContextData *log, int32_t data, const char *name, const char *unit);
+DLT_EXPORT DltReturnValue dlt_user_log_write_int64_attr(DltContextData *log, int64_t data, const char *name, const char *unit);
 
 /**
  * Write a null terminated ASCII string into a DLT log message.
@@ -522,7 +523,7 @@ DltReturnValue dlt_user_log_write_int64_attr(DltContextData *log, int64_t data, 
  * @param text pointer to the parameter written into log message containing null termination.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text);
+DLT_EXPORT DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text);
 
 /**
  * Write a potentially non-null-terminated ASCII string into a DLT log message.
@@ -533,7 +534,7 @@ DltReturnValue dlt_user_log_write_string(DltContextData *log, const char *text);
  * @param length length in bytes of @a text (without any termination character)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_string(DltContextData *log, const char *text, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_string(DltContextData *log, const char *text, uint16_t length);
 
 /**
  * Write a constant null terminated ASCII string into a DLT log message.
@@ -544,7 +545,7 @@ DltReturnValue dlt_user_log_write_sized_string(DltContextData *log, const char *
  * @param text pointer to the parameter written into log message containing null termination.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const char *text);
+DLT_EXPORT DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const char *text);
 
 /**
  * Write a constant, potentially non-null-terminated ASCII string into a DLT log message.
@@ -556,7 +557,7 @@ DltReturnValue dlt_user_log_write_constant_string(DltContextData *log, const cha
  * @param length length in bytes of @a text (without any termination character)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_constant_string(DltContextData *log, const char *text, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_constant_string(DltContextData *log, const char *text, uint16_t length);
 
 /**
  * Write a null terminated UTF8 string into a DLT log message.
@@ -566,7 +567,7 @@ DltReturnValue dlt_user_log_write_sized_constant_string(DltContextData *log, con
  * @param text pointer to the parameter written into log message containing null termination.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_utf8_string(DltContextData *log, const char *text);
+DLT_EXPORT DltReturnValue dlt_user_log_write_utf8_string(DltContextData *log, const char *text);
 
 /**
  * Write a potentially non-null-terminated UTF8 string into a DLT log message.
@@ -577,7 +578,7 @@ DltReturnValue dlt_user_log_write_utf8_string(DltContextData *log, const char *t
  * @param length length in bytes of @a text (without any termination character)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_utf8_string(DltContextData *log, const char *text, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_utf8_string(DltContextData *log, const char *text, uint16_t length);
 
 /**
  * Write a constant null terminated UTF8 string into a DLT log message.
@@ -588,7 +589,7 @@ DltReturnValue dlt_user_log_write_sized_utf8_string(DltContextData *log, const c
  * @param text pointer to the parameter written into log message containing null termination.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_constant_utf8_string(DltContextData *log, const char *text);
+DLT_EXPORT DltReturnValue dlt_user_log_write_constant_utf8_string(DltContextData *log, const char *text);
 
 /**
  * Write a constant, potentially non-null-terminated UTF8 string into a DLT log message.
@@ -600,7 +601,7 @@ DltReturnValue dlt_user_log_write_constant_utf8_string(DltContextData *log, cons
  * @param length length in bytes of @a text (without any termination character)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_constant_utf8_string(DltContextData *log, const char *text, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_constant_utf8_string(DltContextData *log, const char *text, uint16_t length);
 
 /**
  * Write a null-terminated ASCII string with "name" attribute into a DLT log message.
@@ -615,7 +616,7 @@ DltReturnValue dlt_user_log_write_sized_constant_utf8_string(DltContextData *log
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_string_attr(DltContextData *log, const char *text, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_string_attr(DltContextData *log, const char *text, const char *name);
 
 /**
  * Write a potentially non-null-terminated ASCII string with "name" attribute into a DLT log message.
@@ -631,7 +632,7 @@ DltReturnValue dlt_user_log_write_string_attr(DltContextData *log, const char *t
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
 
 /**
  * Write a constant, null-terminated ASCII string with "name" attribute into a DLT log message.
@@ -647,7 +648,7 @@ DltReturnValue dlt_user_log_write_sized_string_attr(DltContextData *log, const c
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_constant_string_attr(DltContextData *log, const char *text, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_constant_string_attr(DltContextData *log, const char *text, const char *name);
 
 /**
  * Write a constant, potentially non-null-terminated ASCII string with "name" attribute into a DLT log message.
@@ -664,7 +665,7 @@ DltReturnValue dlt_user_log_write_constant_string_attr(DltContextData *log, cons
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_constant_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_constant_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
 
 /**
  * Write a null-terminated UTF-8 string with "name" attribute into a DLT log message.
@@ -679,7 +680,7 @@ DltReturnValue dlt_user_log_write_sized_constant_string_attr(DltContextData *log
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_utf8_string_attr(DltContextData *log, const char *text, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_utf8_string_attr(DltContextData *log, const char *text, const char *name);
 
 /**
  * Write a potentially non-null-terminated UTF-8 string with "name" attribute into a DLT log message.
@@ -695,7 +696,7 @@ DltReturnValue dlt_user_log_write_utf8_string_attr(DltContextData *log, const ch
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_utf8_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_utf8_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
 
 /**
  * Write a constant, null-terminated UTF8 string with "name" attribute into a DLT log message.
@@ -711,7 +712,7 @@ DltReturnValue dlt_user_log_write_sized_utf8_string_attr(DltContextData *log, co
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_constant_utf8_string_attr(DltContextData *log, const char *text, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_constant_utf8_string_attr(DltContextData *log, const char *text, const char *name);
 
 /**
  * Write a constant, potentially non-null-terminated UTF8 string with "name" attribute into a DLT log message.
@@ -728,7 +729,7 @@ DltReturnValue dlt_user_log_write_constant_utf8_string_attr(DltContextData *log,
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_sized_constant_utf8_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_sized_constant_utf8_string_attr(DltContextData *log, const char *text, uint16_t length, const char *name);
 
 /**
  * Write a binary memory block into a DLT log message.
@@ -739,7 +740,7 @@ DltReturnValue dlt_user_log_write_sized_constant_utf8_string_attr(DltContextData
  * @param length length in bytes of the parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_raw(DltContextData *log, void *data, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_user_log_write_raw(DltContextData *log, void *data, uint16_t length);
 
 /**
  * Write a binary memory block into a DLT log message.
@@ -751,7 +752,7 @@ DltReturnValue dlt_user_log_write_raw(DltContextData *log, void *data, uint16_t 
  * @param type the format information.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_raw_formatted(DltContextData *log, void *data, uint16_t length, DltFormatType type);
+DLT_EXPORT DltReturnValue dlt_user_log_write_raw_formatted(DltContextData *log, void *data, uint16_t length, DltFormatType type);
 
 /**
  * Write a binary memory block with "name" attribute into a DLT log message.
@@ -767,7 +768,7 @@ DltReturnValue dlt_user_log_write_raw_formatted(DltContextData *log, void *data,
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_raw_attr(DltContextData *log, const void *data, uint16_t length, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_raw_attr(DltContextData *log, const void *data, uint16_t length, const char *name);
 
 /**
  * Write a binary memory block with "name" attribute into a DLT log message.
@@ -784,7 +785,7 @@ DltReturnValue dlt_user_log_write_raw_attr(DltContextData *log, const void *data
  * @param name  the "name" attribute (or NULL)
  * @return value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_write_raw_formatted_attr(DltContextData *log, const void *data, uint16_t length, DltFormatType type, const char *name);
+DLT_EXPORT DltReturnValue dlt_user_log_write_raw_formatted_attr(DltContextData *log, const void *data, uint16_t length, DltFormatType type, const char *name);
 
 /**
  * Trace network message
@@ -796,7 +797,7 @@ DltReturnValue dlt_user_log_write_raw_formatted_attr(DltContextData *log, const 
  * @param payload pointer to network message payload
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_trace_network(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_user_trace_network(DltContext *handle,
                                       DltNetworkTraceType nw_trace_type,
                                       uint16_t header_len,
                                       void *header,
@@ -814,7 +815,7 @@ DltReturnValue dlt_user_trace_network(DltContext *handle,
  * @param allow_truncate Set to > 0 to allow truncating of the message if it is too large.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_trace_network_truncated(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_user_trace_network_truncated(DltContext *handle,
                                                 DltNetworkTraceType nw_trace_type,
                                                 uint16_t header_len,
                                                 void *header,
@@ -835,7 +836,7 @@ DltReturnValue dlt_user_trace_network_truncated(DltContext *handle,
  * @param payload pointer to network message payload
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_trace_network_segmented(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_user_trace_network_segmented(DltContext *handle,
                                                 DltNetworkTraceType nw_trace_type,
                                                 uint16_t header_len,
                                                 void *header,
@@ -851,7 +852,7 @@ DltReturnValue dlt_user_trace_network_segmented(DltContext *handle,
  * This function has to be called first, before using any DLT user lib functions.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_init();
+DLT_EXPORT DltReturnValue dlt_init();
 
 /**
  * Initialize the user lib writing only to file.
@@ -859,7 +860,7 @@ DltReturnValue dlt_init();
  * @param name name of an optional log file
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_init_file(const char *name);
+DLT_EXPORT DltReturnValue dlt_init_file(const char *name);
 
 /**
  * Set maximum file size if lib is configured to write only to file.
@@ -867,14 +868,14 @@ DltReturnValue dlt_init_file(const char *name);
  * @param filesize maximum file size
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_set_filesize_max(unsigned int filesize);
+DLT_EXPORT DltReturnValue dlt_set_filesize_max(unsigned int filesize);
 
 /**
  * Terminate the user lib.
  * This function has to be called when finishing using the DLT user lib.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_free();
+DLT_EXPORT DltReturnValue dlt_free();
 
 /**
  * Check the library version of DLT library.
@@ -882,7 +883,7 @@ DltReturnValue dlt_free();
  * @param user_minor_version the minor version to be compared
  * @return Value from DltReturnValue enum, DLT_RETURN_ERROR if there is a mismatch
  */
-DltReturnValue dlt_check_library_version(const char *user_major_version, const char *user_minor_version);
+DLT_EXPORT DltReturnValue dlt_check_library_version(const char *user_major_version, const char *user_minor_version);
 
 /**
  * Register an application in the daemon.
@@ -890,28 +891,28 @@ DltReturnValue dlt_check_library_version(const char *user_major_version, const c
  * @param description long name of the application
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_app(const char *apid, const char *description);
+DLT_EXPORT DltReturnValue dlt_register_app(const char *apid, const char *description);
 
 /**
  * Unregister an application in the daemon.
  * This function has to be called when finishing using an application.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_unregister_app(void);
+DLT_EXPORT DltReturnValue dlt_unregister_app(void);
 
 /**
  * Unregister an application in the daemon and also flushes the buffered logs.
  * This function has to be called when finishing using an application.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_unregister_app_flush_buffered_logs(void);
+DLT_EXPORT DltReturnValue dlt_unregister_app_flush_buffered_logs(void);
 
 /**
  * Get the application id
  * @param four byte long character array to store the application id
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_get_appid(char *appid);
+DLT_EXPORT DltReturnValue dlt_get_appid(char *appid);
 
 /**
  * Register a context in the daemon.
@@ -921,7 +922,7 @@ DltReturnValue dlt_get_appid(char *appid);
  * @param description long name of the context
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_context(DltContext *handle, const char *contextid, const char *description);
+DLT_EXPORT DltReturnValue dlt_register_context(DltContext *handle, const char *contextid, const char *description);
 
 /**
  * Register a context in the daemon with pre-defined log level and pre-defined trace status.
@@ -935,7 +936,7 @@ DltReturnValue dlt_register_context(DltContext *handle, const char *contextid, c
  *        (DLT_TRACE_STATUS_DEFAULT is not allowed here)
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_context_ll_ts(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_register_context_ll_ts(DltContext *handle,
                                           const char *contextid,
                                           const char *description,
                                           int loglevel,
@@ -950,7 +951,7 @@ DltReturnValue dlt_register_context_ll_ts(DltContext *handle,
  * @param *dlt_log_level_changed_callback This is the fn which will be called when log level is changed
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_context_llccb(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_register_context_llccb(DltContext *handle,
                                           const char *contextid,
                                           const char *description,
                                           void (*dlt_log_level_changed_callback)(char context_id[DLT_ID_SIZE],
@@ -963,14 +964,14 @@ DltReturnValue dlt_register_context_llccb(DltContext *handle,
  * @param handle pointer to an object containing information about one special logging context
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_unregister_context(DltContext *handle);
+DLT_EXPORT DltReturnValue dlt_unregister_context(DltContext *handle);
 
 
 /**
  * Set maximum timeout for re-sending at exit
  * @param timeout_in_milliseconds maximum time to wait until giving up re-sending, default 10000 (equals to 10 seconds)
  */
-int dlt_set_resend_timeout_atexit(uint32_t timeout_in_milliseconds);
+DLT_EXPORT int dlt_set_resend_timeout_atexit(uint32_t timeout_in_milliseconds);
 
 /**
  * Set the logging mode used by the daemon.
@@ -979,7 +980,7 @@ int dlt_set_resend_timeout_atexit(uint32_t timeout_in_milliseconds);
  * @param mode the new logging mode used by the daemon: off, extern, internal, both.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_set_log_mode(DltUserLogMode mode);
+DLT_EXPORT DltReturnValue dlt_set_log_mode(DltUserLogMode mode);
 
 /**
  * Get the state of the connected client to the daemon.
@@ -989,7 +990,7 @@ DltReturnValue dlt_set_log_mode(DltUserLogMode mode);
  * Until then the state is "unknown state".
  * @return -1 = unknown state, 0 = client not connected, 1 = client connected
  */
-int dlt_get_log_state();
+DLT_EXPORT int dlt_get_log_state();
 
 /**
  * Register callback function called when injection message was received
@@ -998,7 +999,7 @@ int dlt_get_log_state();
  * @param (*dlt_injection_callback) function pointer to callback function
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_injection_callback(DltContext *handle, uint32_t service_id,
+DLT_EXPORT DltReturnValue dlt_register_injection_callback(DltContext *handle, uint32_t service_id,
                                                int (*dlt_injection_callback)(uint32_t service_id,
                                                                              void *data,
                                                                              uint32_t length));
@@ -1011,7 +1012,7 @@ DltReturnValue dlt_register_injection_callback(DltContext *handle, uint32_t serv
  * @param priv private data
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_injection_callback_with_id(DltContext *handle, uint32_t service_id,
+DLT_EXPORT DltReturnValue dlt_register_injection_callback_with_id(DltContext *handle, uint32_t service_id,
                                                        int (*dlt_injection_callback)(uint32_t service_id,
                                                                                      void *data,
                                                                                      uint32_t length,
@@ -1023,7 +1024,7 @@ DltReturnValue dlt_register_injection_callback_with_id(DltContext *handle, uint3
  * @param (*dlt_log_level_changed_callback) function pointer to callback function
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_register_log_level_changed_callback(DltContext *handle,
+DLT_EXPORT DltReturnValue dlt_register_log_level_changed_callback(DltContext *handle,
                                                        void (*dlt_log_level_changed_callback)(
                                                            char context_id[DLT_ID_SIZE],
                                                            uint8_t log_level,
@@ -1033,7 +1034,7 @@ DltReturnValue dlt_register_log_level_changed_callback(DltContext *handle,
  * Switch to verbose mode
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_verbose_mode(void);
+DLT_EXPORT DltReturnValue dlt_verbose_mode(void);
 
 /**
  * Check the version of dlt library with library version used of the application.
@@ -1041,7 +1042,7 @@ DltReturnValue dlt_verbose_mode(void);
  * @param user_minor_version version number of application - see dlt_version.h
  *  @return Value from DltReturnValue enum, DLT_RETURN_ERROR if there is a mismatch
  */
-DltReturnValue dlt_user_check_library_version(const char *user_major_version, const char *user_minor_version);
+DLT_EXPORT DltReturnValue dlt_user_check_library_version(const char *user_major_version, const char *user_minor_version);
 
 /**
  * Switch to non-verbose mode
@@ -1050,7 +1051,7 @@ DltReturnValue dlt_user_check_library_version(const char *user_major_version, co
  * Instead, it +allows+ the sending of both Verbose and Non-Verbose messages, depending on which APIs
  * are being called.
  */
-DltReturnValue dlt_nonverbose_mode(void);
+DLT_EXPORT DltReturnValue dlt_nonverbose_mode(void);
 
 /**
  * Use extended header in non verbose mode.
@@ -1058,7 +1059,7 @@ DltReturnValue dlt_nonverbose_mode(void);
  * @param use_extended_header_for_non_verbose Use extended header for non verbose mode if true
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_use_extended_header_for_non_verbose(int8_t use_extended_header_for_non_verbose);
+DLT_EXPORT DltReturnValue dlt_use_extended_header_for_non_verbose(int8_t use_extended_header_for_non_verbose);
 
 /**
  * Send session id configuration.
@@ -1066,7 +1067,7 @@ DltReturnValue dlt_use_extended_header_for_non_verbose(int8_t use_extended_heade
  * @param with_session_id Send session id in each message if enabled
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_with_session_id(int8_t with_session_id);
+DLT_EXPORT DltReturnValue dlt_with_session_id(int8_t with_session_id);
 
 /**
  * Send timestamp configuration.
@@ -1074,7 +1075,7 @@ DltReturnValue dlt_with_session_id(int8_t with_session_id);
  * @param with_timestamp Send timestamp id in each message if enabled
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_with_timestamp(int8_t with_timestamp);
+DLT_EXPORT DltReturnValue dlt_with_timestamp(int8_t with_timestamp);
 
 /**
  * Send ecu id configuration.
@@ -1082,7 +1083,7 @@ DltReturnValue dlt_with_timestamp(int8_t with_timestamp);
  * @param with_ecu_id Send ecu id in each message if enabled
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_with_ecu_id(int8_t with_ecu_id);
+DLT_EXPORT DltReturnValue dlt_with_ecu_id(int8_t with_ecu_id);
 
 /**
  * Set maximum logged log level and trace status of application
@@ -1091,7 +1092,7 @@ DltReturnValue dlt_with_ecu_id(int8_t with_ecu_id);
  * @param tracestatus This is the trace status to be set for the whole application
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_set_application_ll_ts_limit(DltLogLevelType loglevel, DltTraceStatusType tracestatus);
+DLT_EXPORT DltReturnValue dlt_set_application_ll_ts_limit(DltLogLevelType loglevel, DltTraceStatusType tracestatus);
 
 
 /**
@@ -1113,7 +1114,7 @@ DltReturnValue dlt_set_application_ll_ts_limit(DltLogLevelType loglevel, DltTrac
  * @param ll
  * If no item matches or in case of error, the original log-level (\param ll) is returned
  */
-int dlt_env_adjust_ll_from_env(dlt_env_ll_set const *const ll_set,
+DLT_EXPORT int dlt_env_adjust_ll_from_env(dlt_env_ll_set const *const ll_set,
                                char const *const apid,
                                char const *const ctid,
                                int const ll);
@@ -1130,21 +1131,21 @@ int dlt_env_adjust_ll_from_env(dlt_env_ll_set const *const ll_set,
  * @return 0 on success
  * @return -1 on failure
  */
-int dlt_env_extract_ll_set(char **const env, dlt_env_ll_set *const ll_set);
+DLT_EXPORT int dlt_env_extract_ll_set(char **const env, dlt_env_ll_set *const ll_set);
 
-void dlt_env_free_ll_set(dlt_env_ll_set *const ll_set);
+DLT_EXPORT void dlt_env_free_ll_set(dlt_env_ll_set *const ll_set);
 
 /**
  * Enable local printing of messages
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_enable_local_print(void);
+DLT_EXPORT DltReturnValue dlt_enable_local_print(void);
 
 /**
  * Disable local printing of messages
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_disable_local_print(void);
+DLT_EXPORT DltReturnValue dlt_disable_local_print(void);
 
 /**
  * Write a null terminated ASCII string into a DLT log message.
@@ -1153,7 +1154,7 @@ DltReturnValue dlt_disable_local_print(void);
  * @param text pointer to the ASCII string written into log message containing null termination.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_string(DltContext *handle, DltLogLevelType loglevel, const char *text);
+DLT_EXPORT DltReturnValue dlt_log_string(DltContext *handle, DltLogLevelType loglevel, const char *text);
 
 /**
  * Write a null terminated ASCII string and an integer value into a DLT log message.
@@ -1163,7 +1164,7 @@ DltReturnValue dlt_log_string(DltContext *handle, DltLogLevelType loglevel, cons
  * @param data integer value written into the log message
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_string_int(DltContext *handle, DltLogLevelType loglevel, const char *text, int data);
+DLT_EXPORT DltReturnValue dlt_log_string_int(DltContext *handle, DltLogLevelType loglevel, const char *text, int data);
 
 /**
  * Write a null terminated ASCII string and an unsigned integer value into a DLT log message.
@@ -1173,7 +1174,7 @@ DltReturnValue dlt_log_string_int(DltContext *handle, DltLogLevelType loglevel, 
  * @param data unsigned integer value written into the log message
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_string_uint(DltContext *handle, DltLogLevelType loglevel, const char *text, unsigned int data);
+DLT_EXPORT DltReturnValue dlt_log_string_uint(DltContext *handle, DltLogLevelType loglevel, const char *text, unsigned int data);
 
 /**
  * Write an integer value into a DLT log message.
@@ -1182,7 +1183,7 @@ DltReturnValue dlt_log_string_uint(DltContext *handle, DltLogLevelType loglevel,
  * @param data integer value written into the log message
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_int(DltContext *handle, DltLogLevelType loglevel, int data);
+DLT_EXPORT DltReturnValue dlt_log_int(DltContext *handle, DltLogLevelType loglevel, int data);
 
 /**
  * Write an unsigned integer value into a DLT log message.
@@ -1191,7 +1192,7 @@ DltReturnValue dlt_log_int(DltContext *handle, DltLogLevelType loglevel, int dat
  * @param data unsigned integer value written into the log message
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_uint(DltContext *handle, DltLogLevelType loglevel, unsigned int data);
+DLT_EXPORT DltReturnValue dlt_log_uint(DltContext *handle, DltLogLevelType loglevel, unsigned int data);
 
 /**
  * Write an unsigned integer value into a DLT log message.
@@ -1201,13 +1202,13 @@ DltReturnValue dlt_log_uint(DltContext *handle, DltLogLevelType loglevel, unsign
  * @param length length in bytes of the parameter written into log message.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_raw(DltContext *handle, DltLogLevelType loglevel, void *data, uint16_t length);
+DLT_EXPORT DltReturnValue dlt_log_raw(DltContext *handle, DltLogLevelType loglevel, void *data, uint16_t length);
 
 /**
  * Write marker message to DLT.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_log_marker();
+DLT_EXPORT DltReturnValue dlt_log_marker();
 
 /**
  * Get the total size and available size of the shared memory buffer between daemon and applications.
@@ -1217,7 +1218,7 @@ DltReturnValue dlt_log_marker();
  * @param used_size used size of buffer in bytes
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_check_buffer(int *total_size, int *used_size);
+DLT_EXPORT DltReturnValue dlt_user_check_buffer(int *total_size, int *used_size);
 
 /**
  * Try to resend log message in the user buffer. Stops if the dlt_uptime is bigger than
@@ -1225,13 +1226,13 @@ DltReturnValue dlt_user_check_buffer(int *total_size, int *used_size);
  * attempts can be defined with DLT_USER_ATEXIT_RESEND_BUFFER_SLEEP
  * @return number of messages in the user buffer
  */
-int dlt_user_atexit_blow_out_user_buffer(void);
+DLT_EXPORT int dlt_user_atexit_blow_out_user_buffer(void);
 
 /**
  * Try to resend log message in the user buffer.
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_resend_buffer(void);
+DLT_EXPORT DltReturnValue dlt_user_log_resend_buffer(void);
 
 /**
  * Checks the log level passed by the log function if enabled for that context or not.
@@ -1256,8 +1257,8 @@ static inline DltReturnValue dlt_user_is_logLevel_enabled(DltContext *handle, Dl
 }
 
 #   ifdef DLT_TEST_ENABLE
-void dlt_user_test_corrupt_user_header(int enable);
-void dlt_user_test_corrupt_message_size(int enable, int16_t size);
+DLT_EXPORT void dlt_user_test_corrupt_user_header(int enable);
+DLT_EXPORT void dlt_user_test_corrupt_message_size(int enable, int16_t size);
 #   endif /* DLT_TEST_ENABLE */
 
 #   ifdef __cplusplus

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -86,6 +86,7 @@ if (WITH_DLT_UNIT_TESTS)
 
     add_library(dlt_daemon ${library_SRCS})
     target_link_libraries(dlt_daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
+    target_compile_definitions(dlt_daemon PRIVATE DLT_UNIT_TEST_LIB)
 
     install(TARGETS dlt_daemon
             RUNTIME DESTINATION bin

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1119,6 +1119,9 @@ static DltReturnValue dlt_daemon_create_pipes_dir(char *dir)
 }
 #endif
 
+// Unit tests have their own main function, avoid multiple definition with -DBUILD_SHARED_LIBS=OFF.
+#ifndef DLT_UNIT_TEST_LIB
+
 /**
  * Main function of tool.
  */
@@ -1355,6 +1358,8 @@ int main(int argc, char *argv[])
     return 0;
 
 } /* main() */
+
+#endif
 
 int dlt_daemon_local_init_p1(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose)
 {

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -46,6 +46,10 @@ else()
 endif()
 
 target_link_libraries(dlt ${RT_LIBRARY} ${SOCKET_LIBRARY} Threads::Threads)
+set_target_properties(dlt PROPERTIES
+    C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN 1
+)
 
 target_include_directories(dlt
     PUBLIC

--- a/src/lib/dlt_filetransfer.c
+++ b/src/lib/dlt_filetransfer.c
@@ -126,7 +126,7 @@ void stringHash(const char *str, uint32_t *hash)
  * @param ok *ok == 0 -> error; *ok == 1 -> ok
  * @return Returns a unique number associated with each filename
  */
-uint32_t getFileSerialNumber(const char *file, int *ok)
+DLT_EXPORT uint32_t getFileSerialNumber(const char *file, int *ok)
 {
     struct stat st;
     uint32_t ret;

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -39,6 +39,7 @@
 #include <sys/stat.h> /* for mkdir() */
 #include <sys/wait.h>
 
+#include "dlt_export.h"
 #include "dlt_user_shared.h"
 #include "dlt_common.h"
 #include "dlt_common_cfg.h"
@@ -114,12 +115,12 @@ static char *return_type[] =
 { "ok", "not_supported", "error", "perm_denied", "warning", "", "", "", "no_matching_context_id" };
 
 /* internal function definitions */
-int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete);
-int dlt_buffer_reset(DltBuffer *buf);
-int dlt_buffer_increase_size(DltBuffer *buf);
-int dlt_buffer_minimize_size(DltBuffer *buf);
-void dlt_buffer_write_block(DltBuffer *buf, int *write, const unsigned char *data, unsigned int size);
-void dlt_buffer_read_block(DltBuffer *buf, int *read, unsigned char *data, unsigned int size);
+DLT_EXPORT int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete);
+DLT_EXPORT int dlt_buffer_reset(DltBuffer *buf);
+DLT_EXPORT int dlt_buffer_increase_size(DltBuffer *buf);
+DLT_EXPORT int dlt_buffer_minimize_size(DltBuffer *buf);
+DLT_EXPORT void dlt_buffer_write_block(DltBuffer *buf, int *write, const unsigned char *data, unsigned int size);
+DLT_EXPORT void dlt_buffer_read_block(DltBuffer *buf, int *read, unsigned char *data, unsigned int size);
 
 void dlt_print_hex(uint8_t *ptr, int size)
 {

--- a/src/shared/dlt_user_shared.h
+++ b/src/shared/dlt_user_shared.h
@@ -68,6 +68,7 @@
 #ifndef DLT_USER_SHARED_H
 #define DLT_USER_SHARED_H
 
+#include "dlt_export.h"
 #include "dlt_types.h"
 #include "dlt_user.h"
 
@@ -191,14 +192,14 @@ typedef struct
  * @param mtype user message type of internal message
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_set_userheader(DltUserHeader *userheader, uint32_t mtype);
+DLT_EXPORT DltReturnValue dlt_user_set_userheader(DltUserHeader *userheader, uint32_t mtype);
 
 /**
  * Check if user header contains its marker
  * @param userheader pointer to the userheader
  * @return 0 no, 1 yes, negative value if there was an error
  */
-int dlt_user_check_userheader(DltUserHeader *userheader);
+DLT_EXPORT int dlt_user_check_userheader(DltUserHeader *userheader);
 
 /**
  * Atomic write to file descriptor, using vector of 2 elements
@@ -209,7 +210,7 @@ int dlt_user_check_userheader(DltUserHeader *userheader);
  * @param len2 length of second segment of data to be written
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
+DLT_EXPORT DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
 
 /**
  * Atomic write to file descriptor, using vector of 2 elements  with a timeout of 1s
@@ -220,7 +221,7 @@ DltReturnValue dlt_user_log_out2(int handle, void *ptr1, size_t len1, void *ptr2
  * @param len2 length of second segment of data to be written
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
+DLT_EXPORT DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2);
 
 /**
  * Atomic write to file descriptor, using vector of 3 elements
@@ -233,7 +234,7 @@ DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len
  * @param len3 length of third segment of data to be written
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
+DLT_EXPORT DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
 
 /**
  * Atomic write to file descriptor, using vector of 3 elements with a timeout of 1s
@@ -246,7 +247,7 @@ DltReturnValue dlt_user_log_out3(int handle, void *ptr1, size_t len1, void *ptr2
  * @param len3 length of third segment of data to be written
  * @return Value from DltReturnValue enum
  */
-DltReturnValue dlt_user_log_out3_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
+DLT_EXPORT DltReturnValue dlt_user_log_out3_with_timeout(int handle, void *ptr1, size_t len1, void *ptr2, size_t len2, void *ptr3, size_t len3);
 
 
 #endif /* DLT_USER_SHARED_H */

--- a/tests/gtest_dlt_daemon_offline_log.cpp
+++ b/tests/gtest_dlt_daemon_offline_log.cpp
@@ -35,7 +35,7 @@ extern "C"
 #define DLT_OFFLINE_LOGSTORAGE_FILTER_ERROR 1
 #define DLT_CONFIG_FILE_SECTIONS 3
 
-unsigned int g_logstorage_cache_max;
+extern unsigned int g_logstorage_cache_max;
 /* Begin Method: dlt_logstorage::t_dlt_logstorage_list_add*/
 TEST(t_dlt_logstorage_list_add, normal)
 {


### PR DESCRIPTION
This disables unconditional export of symbols from the shared library `libdlt` in favor of an opt-in approach.

- only symbols marked DLT_EXPORT are exposed from the shared library
- this commit adds DLT_EXPORT on all symbols declared in the installed header files
- static library builds of `libdlt` are unaffected by this change (`BUILD_SHARED_LIBS=OFF`)

```
# Build previous HEAD
$> nm --dynamic --defined-only ./build/src/lib/libdlt.so | cut -f3 -d' ' | sort > ./before
# Build this commit
$> nm --dynamic --defined-only ./build/src/lib/libdlt.so | cut -f3 -d' ' | sort > ./after
# Summary (Linux, with maximum options enable, -DDLT_IPC=UNIX_SOCKET)
$> wc -l ./before ./after
  331 ./before
  272 ./after
```

The sorted list of remaining symbols is:
```
$> cat ./after
dlt_buffer_check_size
... all prefixed with dlt ...
dlt_with_timestamp
get_filename_ext
getFileSerialNumber
multiple_files_buffer_file_name
... more multiple_files_buffer_* ...
multiple_files_buffer_write_chunk
```

So some functions need to be revised:

1.  `dlt_buffer_*` defined in `src/shared/dlt_common.c`
    These functions are required to be exported but they are not declared in any header.
2. `get_filename_ext`  declared in `include/dlt/dlt_common.h`
    It is not prefixed with *dlt*. Should it really be exported?
3. `getFileSerialNumber` defined in `src/lib/dlt_filetransfer.c`
    This function should be renamed to have a *dlt* prefix. It is also required to be exported but not declared in any header.
4. `multiple_files_buffer_*` declared in `include/dlt/dlt_multiple_files.h`
    These functions appear to be public API, too but are not prefixed with *dlt*.