### PR TITLE
Fix DLT-Multinode: Gateway does not recognize reset of passive node #551

### DIFF
--- a/src/daemon/dlt_daemon_event_handler.c
+++ b/src/daemon/dlt_daemon_event_handler.c
@@ -228,18 +228,28 @@ int dlt_daemon_handle_event(DltEventHandler *pEvent,
         if (pEvent->pfd[i].revents & DLT_EV_MASK_REJECTED) {
             /* An error occurred, we need to clean-up the concerned event
              */
-            if (type == DLT_CONNECTION_CLIENT_MSG_TCP)
+            if (type == DLT_CONNECTION_CLIENT_MSG_TCP) {
                 /* To transition to BUFFER state if this is final TCP client connection,
                  * call dedicated function. this function also calls
                  * dlt_event_handler_unregister_connection() inside the function.
                  */
                 dlt_daemon_close_socket(fd, daemon, daemon_local, 0);
-            else
-                dlt_event_handler_unregister_connection(pEvent,
-                                                        daemon_local,
-                                                        fd);
-
-            continue;
+                continue;
+            }
+            else if (type == DLT_CONNECTION_GATEWAY) {
+                /* Let the callback function
+                 * dlt_gateway_process_passive_node_messages handle the
+                 * disconnect which was triggered by TCP keepalive after a
+                 * network disconnect. If we directly called
+                 * dlt_event_handler_unregister_connection() here the dlt_gateway would
+                 * not notice that the connection was closed.
+                 */
+                dlt_vlog(LOG_DEBUG, "Connection to dlt gateway broken.\n");
+            }
+            else {
+                dlt_event_handler_unregister_connection(pEvent, daemon_local, fd);
+                continue;
+            }
         }
 
         /* Get the function to be used to handle the event */

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -985,8 +985,9 @@ int dlt_gateway_establish_connections(DltGateway *gateway,
                 }
             }
             else {
-                dlt_log(LOG_DEBUG,
-                        "Passive Node is not up. Connection failed.\n");
+                dlt_vlog(LOG_WARNING,
+                         "Passive Node %s is not up. Connection failed.\n",
+                         con->ecuid);
 
                 con->timeout_cnt++;
 


### PR DESCRIPTION
Enable TCP keepalive to detect broken connections due to network disconnects. Without this in cases where no TCP FIN or RST package is received from the server, the dlt_client will never notice that it was disconnected from the server. Thus it will not reconnect when the server is available again. Also improve logging output to see which connection fails.

See this #551 and the discussion here: https://github.com/COVESA/dlt-daemon/discussions/559

To reproduce this issue fixed here you can run a dlt_daemon as gateway on one machine and a one dlt_daemon as a passive node on another machine or docker container. Then disconnect the network cable or `sudo ifconfig eth0 down/up`. In the docker case you can disconnect the container from the bridge by running `docker network disconnect/connect <docker network name> <container name>`