### PR TITLE
filetransfer: function added for cancelable filetransfer

### DIFF
--- a/include/dlt/dlt_filetransfer.h
+++ b/include/dlt/dlt_filetransfer.h
@@ -48,6 +48,8 @@
 #define DLT_FILETRANSFER_ERROR_FILE_DATA_USER_BUFFER_FAILED -501
 /* ! Error code for dlt_user_log_file_end */
 #define DLT_FILETRANSFER_ERROR_FILE_END -600
+/* ! Error code for dlt_user_log_file_end */
+#define DLT_FILETRANSFER_ERROR_FILE_END_USER_CANCELLED -601
 /* ! Error code for dlt_user_log_file_infoAbout */
 #define DLT_FILETRANSFER_ERROR_INFO_ABOUT -700
 /* ! Error code for dlt_user_log_file_packagesCount */
@@ -114,6 +116,17 @@ extern int dlt_user_log_file_header_alias(DltContext *fileContext, const char *f
  * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
  */
 extern int dlt_user_log_file_header(DltContext *fileContext, const char *filename);
+
+//* !Transfer the content data of a file. */
+/**See the Mainpages.c for more informations.
+ * @param fileContext Specific context to log the file to dlt
+ * @param filename Absolute file path
+ * @param packageToTransfer Package number to transfer. If this param is LONG_MAX, the whole file will be transferred with a specific timeout
+ * @param timeout Timeout to wait between dlt logs. Important because the dlt FIFO should not be flooded. Default is defined by MIN_TIMEOUT. The given timeout in ms can not be smaller than MIN_TIMEOUT.
+ * @param fileCancelTransferFlag is a bool pointer to cancel the filetransfer on demand. For example in case of application shutdown event outstanding file transfer should abort and return
+ * @return Returns 0 if everything was okey. If there was a failure value < 0 will be returned.
+ */
+extern int dlt_user_log_file_data_cancelable(DltContext *fileContext, const char *filename, int packageToTransfer, int timeout, bool *const fileCancelTransferFlag);
 
 
 /* !Transfer the content data of a file. */

--- a/tests/start_filetransfer_test.sh
+++ b/tests/start_filetransfer_test.sh
@@ -6,10 +6,13 @@ fullpath="$(pwd)/testfile_filetransfer.txt"
 dlt-daemon &
 sleep 1
 #start dlt-test-receiver
-./../build/tests/dlt_test_receiver -f localhost &
+dlt_test_receiver -f localhost &
 sleep 1
-#send file to daemon
-dlt-example-filetransfer $fullpath &
+# send file to daemon with file info header
+dlt-example-filetransfer -i $fullpath &
+sleep 1
+# send cancelable file to daemon with file info header
+dlt-example-filetransfer -i $fullpath -p &
 sleep 1
 #create md5 sum
 md5_1=($(md5sum $file))


### PR DESCRIPTION
dlt filetransfer cancelable with a bool flag added. added a new example application to test this function. modified shell script to run test easily.
This enables cancellation for example to shutdown faster.


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>