### PR TITLE
Upstream portability and security fixes

### DIFF
--- a/src/core_dump_handler/dlt_cdh_context.c
+++ b/src/core_dump_handler/dlt_cdh_context.c
@@ -293,6 +293,10 @@ cdh_status_t list_dircontent_to(const char *p_dirname, FILE *p_fout)
 
         case S_IFLNK:
             l_size = readlink(l_fullpath, l_linkpath, sizeof(l_linkpath));
+            if (l_size < 0) {
+                syslog(LOG_ERR, "ERR Cannot read link '%s' [%s]", l_fullpath, strerror(errno));
+                break;
+            }
             l_linkpath[l_size] = 0;
             fprintf(p_fout, " -> %s\n", l_linkpath);
             break;

--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -22,7 +22,6 @@
 #include <stdlib.h>
 #include <limits.h>
 #include <ctype.h>
-#include <sys/syslog.h>
 #include <syslog.h>
 #include <sys/stat.h>
 #include <sys/stat.h>

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -494,7 +494,7 @@ DLT_STATIC void dlt_logstorage_open_log_output_file(DltLogStorageFilterConfig *c
     FILE *file = fopen(fpath, mode);
     if (file == NULL) {
         dlt_vlog(LOG_DEBUG, "%s: could not open configuration file\n", __func__);
-        return -1;
+        return;
     }
     config->fd = fileno(file);
     if (config->gzip_compression) {


### PR DESCRIPTION
- Avoid buffer underrun on readlink failure.
- Don't return int from void function.
- Don't include <sys/syslog.h> which appears to be
  an alternative path for <syslog.h>.