### PR TITLE
Close config file handle on error.

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -579,14 +579,18 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                     else if (strcmp(token, "RingbufferMaxSize") == 0)
                     {
                         if (dlt_daemon_check_numeric_setting(token,
-                                value, &(daemon_local->RingbufferMaxSize)) < 0)
+                                value, &(daemon_local->RingbufferMaxSize)) < 0) {
+                            fclose (pFile);
                             return -1;
+                        }
                     }
                     else if (strcmp(token, "RingbufferStepSize") == 0)
                     {
                         if (dlt_daemon_check_numeric_setting(token,
-                                value, &(daemon_local->RingbufferStepSize)) < 0)
+                                value, &(daemon_local->RingbufferStepSize)) < 0) {
+                            fclose (pFile);
                             return -1;
+                        }
                     }
                     else if (strcmp(token, "SharedMemorySize") == 0)
                     {
@@ -755,8 +759,10 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                     else if (strcmp(token, "DaemonFIFOSize") == 0)
                     {
                         if (dlt_daemon_check_numeric_setting(token,
-                                value, &(daemon_local->daemonFifoSize)) < 0)
+                                value, &(daemon_local->daemonFifoSize)) < 0) {
+                            fclose (pFile);
                             return -1;
+                        }
 #ifndef __linux__
                             printf("Option DaemonFIFOSize is set but only supported on Linux. Ignored.\n");
 #endif

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -573,8 +573,10 @@ int option_file_parser(DltDaemonLocal *daemon_local)
                     else if (strcmp(token, "RingbufferMinSize") == 0)
                     {
                         if (dlt_daemon_check_numeric_setting(token,
-                                value, &(daemon_local->RingbufferMinSize)) < 0)
+                                value, &(daemon_local->RingbufferMinSize)) < 0) {
+                            fclose (pFile);
                             return -1;
+                        }
                     }
                     else if (strcmp(token, "RingbufferMaxSize") == 0)
                     {


### PR DESCRIPTION
If parsing of config file fails, close the file before returning an error.