### PR TITLE
Return error correctly when reading a file.

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1922,7 +1922,7 @@ static char* file_read_everything(FILE* const file, const size_t sizeLimit)
     if (fstat(fd, &s_buf) < 0) {
         dlt_log(LOG_WARNING, "failed to stat file size\n");
         fclose(file);
-        return -1;
+        return NULL;
     }
 
     /* Size limit includes NULL terminator. */


### PR DESCRIPTION
The return value of the function file_read_everything is char*.
In case of an error, NULL should be returned. If we return an integer we get an error:

`error: incompatible integer to pointer conversion returning 'int' from a function with result type 'char *' [-Wint-conversion]`

Also, returning -1 is not handled at the calling site and would result in the dlt_daemon_local_ecu_version_init function to return success where it should have returned a failure:


```
if (daemon_local->flags.ecuSoftwareVersionFileField[0] != '\0') {
        daemon->ECUVersionString = file_read_field(f, daemon_local->flags.ecuSoftwareVersionFileField);
    } else {
        daemon->ECUVersionString = file_read_everything(f, DLT_DAEMON_TEXTBUFSIZE);
    }

    fclose(f);

    return (daemon->ECUVersionString != NULL) ? 0 : -1;
```
