### PR TITLE
Make sure copy into fixed size buffer does not overflow.

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -609,7 +609,7 @@ int dlt_logstorage_open_log_file(DltLogStorageFilterConfig *config,
             }
             config->working_file_name = strdup((*newest)->name);
         }
-        strcat(absolute_file_path, config->working_file_name);
+        strncat(absolute_file_path, config->working_file_name, strlen(config->working_file_name));
 
         dlt_vlog(LOG_DEBUG,
                  "%s: Number of log files-newest file-wrap_id [%u]-[%s]-[%u]\n",
@@ -724,7 +724,7 @@ int dlt_logstorage_open_log_file(DltLogStorageFilterConfig *config,
                            0,
                            sizeof(absolute_file_path) / sizeof(char));
                     strcat(absolute_file_path, storage_path);
-                    strcat(absolute_file_path, (*head)->name);
+                    strncat(absolute_file_path, (*head)->name, strlen((*head)->name));
                     dlt_vlog(LOG_DEBUG,
                              "%s: Remove '%s' (num_log_files: %d, config->num_files:%d, file_name:%s)\n",
                              __func__, absolute_file_path, num_log_files,


### PR DESCRIPTION
Use strncat and strlen instead of strcat to avoid overflow of fixed size buffer.