### PR TITLE
dlt_multiple_files: Fix missing string null-terminator

### DIFF
--- a/src/shared/dlt_multiple_files.c
+++ b/src/shared/dlt_multiple_files.c
@@ -100,7 +100,7 @@ unsigned int multiple_files_buffer_storage_dir_info(const char *path, const char
 
         if ((tmp_new != NULL) && (strlen(tmp_new) < NAME_MAX)) {
             strncpy(newest, tmp_new, NAME_MAX);
-            oldest[NAME_MAX] = '\0';
+            newest[NAME_MAX] = '\0';
         } else if ((tmp_new != NULL) && (strlen(tmp_new) >=  NAME_MAX)) {
             printf("length mismatch of file %s\n", tmp_new);
         }


### PR DESCRIPTION
The `newest` string may miss null-terminator, I assume it was supposed to be like this:
```
strncpy(newest, tmp_new, NAME_MAX);
newest[NAME_MAX] = '\0';
```

Note: the link in topic: `Please make sure to follow the [Rules for commit messages](https://at.projects.covesa.org/wiki/display/PROJ/Rules+for+Commit+Messages` does not work for me so commit message maybe incorrect. Error: `We can’t connect to the server at at.projects.covesa.org.`