### PR TITLE
watchdog: fix another possible watchdog timeout

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -3478,7 +3478,22 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
         /* Not enough bytes received to remove*/
         return DLT_DAEMON_ERROR_UNKNOWN;
 
+#ifdef DLT_SYSTEMD_WATCHDOG_ENABLE
+    const unsigned int start_time = dlt_uptime();
+#endif
+
     while (1) {
+#ifdef DLT_SYSTEMD_WATCHDOG_ENABLE
+        const unsigned int uptime = dlt_uptime();
+        if ((uptime - start_time) / 10000 > daemon->watchdog_trigger_interval) {
+            dlt_vlog(LOG_WARNING,
+                     "spent already 1 watchdog trigger interval in %s, yielding to process other events.\n", __func__);
+            if (sd_notify(0, "WATCHDOG=1") < 0)
+                dlt_vlog(LOG_CRIT, "Could not reset systemd watchdog from %s\n", __func__);
+            break;
+        }
+#endif
+
         /* get log message from SHM then store into receiver buffer */
         size = dlt_shm_pull(&(daemon_local->dlt_shm),
                             daemon_local->recv_buf_shm,


### PR DESCRIPTION
dlt_daemon_process_user_message_log prior to this
commit was running without limit, meaning when a lot of messages have to be transmitted dlt-daemon might
be killed by systemd watchdog due to being busy
with sending and not updating the watchdog anymore. This commit introduces a timeout in dlt_daemon_process_user_message_log which allows this function to run at most watchdog_trigger_interval seconds.


This MR extends the logic introduced in https://github.com/COVESA/dlt-daemon/pull/595 as the original commit still allowed systemd to kill dlt-daemon


To test we need the following things
* dlt-daemon started via systemd with enabled watchdog
* a lot of logging going into the daemon

Excecute the script below on your test system.
It spawns a lot of dlt-receive proceses, the goal is for dlt-daemon to survive.

```
end_time=$((SECONDS+180))

while [ $SECONDS -lt $end_time ]; do 
  dlt-receive -a 127.1 &
done 

killall -9 dlt-receive

if [[ $(uname) == "Linux" ]]; then
  systemctl status dlt.service
  echo Service should be running for > 3 minutes
else
  pidin -faAt | grep dlt-daemon | grep -v grep
  echo Service should be running at least since system boot
fi

```


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>