### PR TITLE
dlt-system: add config to use uptime only

### DIFF
--- a/doc/dlt-system.conf.5.md
+++ b/doc/dlt-system.conf.5.md
@@ -93,6 +93,17 @@ Map journal log levels to DLT log levels.
 
     Default: 1
 
+## JournalUseOriginalTimestamp
+
+Use the original timestamp (uptime when the event actually occured) as DLT timestamp.
+
+    Default: 1
+
+## JournalUseUptimeOnly
+
+Ignore the timestamp, show uptime (when the event actually occured) only in payload.
+
+    Default: 0
 
 # FILETRANSFER OPTIONS
 

--- a/src/system/dlt-system-journal.c
+++ b/src/system/dlt-system-journal.c
@@ -286,27 +286,39 @@ void get_journal_msg(sd_journal *j, DltSystemConfiguration *config)
         else
             snprintf(buffer_priority, DLT_SYSTEM_JOURNAL_BUFFER_SIZE, "prio_unknown:");
 
-        /* write log entry */
-        if (config->Journal.UseOriginalTimestamp == 0) {
+        if (config->Journal.UseUptimeOnly == 1) {
+            /* write log entry (uptime only, no timestamp) */
             DLT_LOG(journalContext, loglevel,
-                    DLT_STRING(timestamp.real),
-                    DLT_STRING(timestamp.monotonic),
-                    DLT_STRING(buffer_process),
-                    DLT_STRING(buffer_priority),
-                    DLT_STRING(buffer_message)
-                    );
-
-        }
-        else {
-            /* since we are talking about points in time, I'd prefer truncating over arithmetic rounding */
-            ts = (uint32_t)(atof(timestamp.monotonic) * 10000);
-            DLT_LOG_TS(journalContext, loglevel, ts,
-                        DLT_STRING(timestamp.real),
+                        DLT_STRING(timestamp.monotonic),
                         DLT_STRING(buffer_process),
                         DLT_STRING(buffer_priority),
                         DLT_STRING(buffer_message)
                         );
         }
+        else {
+            /* write log entry (including timestamp) */
+            if (config->Journal.UseOriginalTimestamp == 0) {
+                DLT_LOG(journalContext, loglevel,
+                        DLT_STRING(timestamp.real),
+                        DLT_STRING(timestamp.monotonic),
+                        DLT_STRING(buffer_process),
+                        DLT_STRING(buffer_priority),
+                        DLT_STRING(buffer_message)
+                        );
+
+            }
+            else {
+                /* since we are talking about points in time, I'd prefer truncating over arithmetic rounding */
+                ts = (uint32_t)(atof(timestamp.monotonic) * 10000);
+                DLT_LOG_TS(journalContext, loglevel, ts,
+                            DLT_STRING(timestamp.real),
+                            DLT_STRING(buffer_process),
+                            DLT_STRING(buffer_priority),
+                            DLT_STRING(buffer_message)
+                            );
+            }
+        }
+
 
         if (journal_checkUserBufferForFreeSpace() == -1) {
             /* buffer is nearly full */

--- a/src/system/dlt-system-options.c
+++ b/src/system/dlt-system-options.c
@@ -289,6 +289,10 @@ int read_configuration_file(DltSystemConfiguration *config, char *file_name)
             {
                 config->Journal.UseOriginalTimestamp = atoi(value);
             }
+            else if (strcmp(token, "JournalUseUptimeOnly") == 0)
+            {
+                config->Journal.UseUptimeOnly = atoi(value);
+            }
 
             /* File transfer */
             else if (strcmp(token, "FiletransferEnable") == 0)

--- a/src/system/dlt-system.conf
+++ b/src/system/dlt-system.conf
@@ -77,6 +77,9 @@ JournalMapLogLevels = 1
 # Use the original timestamp (uptime when the event actually occured) as DLT timestamp (Default: 1)
 JournalUseOriginalTimestamp = 1
 
+# Ignore the timestamp, show uptime (when the event actually occured) only in payload (Default: 0)
+JournalUseUptimeOnly = 0
+
 ########################################################################
 # Filetransfer Manager
 ########################################################################

--- a/src/system/dlt-system.h
+++ b/src/system/dlt-system.h
@@ -126,6 +126,7 @@ typedef struct {
     int Follow;
     int MapLogLevels;
     int UseOriginalTimestamp;
+    int UseUptimeOnly;
 #ifdef DLT_SYSTEMD_WATCHDOG_ENFORCE_MSG_RX_ENABLE_DLT_SYSTEM
     int MessageReceived;
 #endif


### PR DESCRIPTION
Add a new JournalUseUptimeOnly config toggle. With this toggle you can supress date and time from the dlt-system payload, so we show only the uptime of the system.
This toggle is for data protection purposes.

The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sub>Daniel Weber, [daniel.w.weber@mercedes-benz.com](mailto:daniel.w.weber@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sub>