### PR TITLE
dlt-user: fix invalid return in dlt_user_log_write_start_internal

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -1838,7 +1838,7 @@ DltReturnValue dlt_user_log_write_start_internal(DltContext *handle,
         return DLT_RETURN_WRONG_PARAMETER;
     } else if (ret == DLT_RETURN_LOGGING_DISABLED) {
         log->handle = NULL;
-        return DLT_RETURN_OK;
+        return ret;
     }
 
     ret = dlt_user_log_write_start_init(handle, log, loglevel, is_verbose);

--- a/tests/gtest_dlt_user.cpp
+++ b/tests/gtest_dlt_user.cpp
@@ -173,11 +173,11 @@ TEST(t_dlt_user_log_write_start, normal)
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_INFO));
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
     /* To test the default behaviour and the default log level set to DLT_LOG_INFO */
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_OFF));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start(&context, &contextData, DLT_LOG_OFF));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEBUG));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start(&context, &contextData, DLT_LOG_DEBUG));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start(&context, &contextData, DLT_LOG_VERBOSE));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start(&context, &contextData, DLT_LOG_VERBOSE));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
 
     EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));
@@ -268,11 +268,11 @@ TEST(t_dlt_user_log_write_start_id, normal)
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_INFO, messageid));
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
     /* To test the default behaviour and the default log level set to DLT_LOG_INFO */
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_OFF, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_OFF, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_DEBUG, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_DEBUG, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_VERBOSE, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_VERBOSE, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
 
     messageid = UINT32_MAX;
@@ -287,11 +287,11 @@ TEST(t_dlt_user_log_write_start_id, normal)
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_INFO, messageid));
     EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_finish(&contextData));
     /* To test the default behaviour and the default log level set to DLT_LOG_INFO */
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_OFF, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_OFF, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_DEBUG, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_DEBUG, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
-    EXPECT_LE(DLT_RETURN_OK, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_VERBOSE, messageid));
+    EXPECT_LE(DLT_RETURN_LOGGING_DISABLED, dlt_user_log_write_start_id(&context, &contextData, DLT_LOG_VERBOSE, messageid));
     EXPECT_LE(DLT_RETURN_WRONG_PARAMETER, dlt_user_log_write_finish(&contextData));
 
     EXPECT_LE(DLT_RETURN_OK, dlt_unregister_context(&context));


### PR DESCRIPTION
dlt_user_log_write_start_internal might return OK when the buffer was not initialized, this can lead to other functions assuming that the buffer was setup correctly and thus access invalid memory.


The program was tested solely for our own use cases, which might differ from yours.
Licensed under Mozilla Public License Version 2.0

<sup>Alexander Mohr, <alexander.m.mohr@mercedes-benz.com>, Mercedes-Benz Tech Innovation GmbH, [imprint](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)</sup>