### PR TITLE
daemon: Prevent new daemon created on same machine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,7 @@ if(WITH_GIT_SUBMODULE)
 endif()
 
 if(WITH_DLT_UNIT_TESTS)
+    set(DLT_IPC "UNIX_SOCKET")
     find_package(GTest)
     if(GTEST_FOUND)
         find_package(PkgConfig REQUIRED)

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1590,14 +1590,35 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
     /* open named pipe(FIFO) to receive DLT messages from users */
     umask(0);
 
-    /* Try to delete existing pipe, ignore result of unlink */
+    /* Valid fifo means there is a daemon running, stop init phase of the new */
     const char *tmpFifo = daemon_local->flags.daemonFifoName;
-    unlink(tmpFifo);
+    if (access(tmpFifo, F_OK) == 0) {
+        dlt_vlog(LOG_WARNING, "FIFO user %s is in use (%s)!\n",
+                 tmpFifo, strerror(errno));
+        return -1;
+    }
 
     ret = mkfifo(tmpFifo, S_IRUSR | S_IWUSR | S_IWGRP);
 
     if (ret == -1) {
         dlt_vlog(LOG_WARNING, "FIFO user %s cannot be created (%s)!\n",
+                 tmpFifo, strerror(errno));
+        return -1;
+    } /* if */
+
+    const char* nameDir = "/tmp";
+    int dir_fd;
+    dir_fd = open(nameDir, O_RDONLY);
+    if (dir_fd == -1) {
+        dlt_vlog(LOG_WARNING, "Directory %s of fifo  cannot be opened (%s)!\n",
+                 nameDir, strerror(errno));
+        return -1;
+    }
+
+    fd = openat(dir_fd, tmpFifo, O_RDWR);
+
+    if (fd == -1) {
+        dlt_vlog(LOG_WARNING, "FIFO user %s cannot be opened (%s)!\n",
                  tmpFifo, strerror(errno));
         return -1;
     } /* if */
@@ -1608,7 +1629,7 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
         struct group *group_dlt = getgrnam(daemon_local->flags.daemonFifoGroup);
 
         if (group_dlt) {
-            ret = chown(tmpFifo, -1, group_dlt->gr_gid);
+            ret = fchown(fd, -1, group_dlt->gr_gid);
 
             if (ret == -1)
                 dlt_vlog(LOG_ERR, "FIFO user %s cannot be chowned to group %s (%s)\n",
@@ -1627,14 +1648,6 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
                      strerror(errno));
         }
     }
-
-    fd = open(tmpFifo, O_RDWR);
-
-    if (fd == -1) {
-        dlt_vlog(LOG_WARNING, "FIFO user %s cannot be opened (%s)!\n",
-                 tmpFifo, strerror(errno));
-        return -1;
-    } /* if */
 
 #ifdef __linux__
     /* F_SETPIPE_SZ and F_GETPIPE_SZ are only supported for Linux.

--- a/src/daemon/dlt_daemon_unix_socket.c
+++ b/src/daemon/dlt_daemon_unix_socket.c
@@ -145,7 +145,7 @@ int dlt_daemon_unix_socket_open(int *sock, char *sock_path, int type, int mask)
     addr.sun_family = AF_UNIX;
     memcpy(addr.sun_path, sock_path, sizeof(addr.sun_path));
 
-    if (unlink(sock_path) != 0) {
+    if (unlink(sock_path) != 0 && (errno != ENOENT)) {
         dlt_vlog(LOG_WARNING, "%s: unlink() failed: %s\n",
                 __func__, strerror(errno));
     }


### PR DESCRIPTION
- Only one daemon on the machine listening to fifo
- fifo will not be unlinked by the new daemon 


