### PR TITLE
daemon: refactor IPC usage

### DIFF
--- a/.github/workflows/cmake-ctest.yml
+++ b/.github/workflows/cmake-ctest.yml
@@ -9,6 +9,8 @@ on:
 env:
   BUILD_TYPE: Release
   WITH_DLT_COVERAGE: ON
+  WITH_DLT_SHM_ENABLE: ON
+  DLT_IPC: "UNIX_SOCKET"
   BUILD_GMOCK: OFF
 
 jobs:
@@ -27,6 +29,8 @@ jobs:
       run: |
           cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} \
                                                -DWITH_DLT_COVERAGE=${{env.WITH_DLT_COVERAGE}} \
+                                               -DWITH_DLT_SHM_ENABLE=${{env.WITH_DLT_SHM_ENABLE}} \
+                                               -DDLT_IPC=${{env.DLT_IPC}} \
                                                -DBUILD_GMOCK=${{env.BUILD_GMOCK}}
 
     - name: Build

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -1585,19 +1585,38 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
 {
     int ret;
     int fd = -1;
+    int dir_fd = -1;
     int fifo_size;
 
     /* open named pipe(FIFO) to receive DLT messages from users */
     umask(0);
 
-    /* Try to delete existing pipe, ignore result of unlink */
+    /* Valid fifo means there is a daemon running, stop init phase of the new */
     const char *tmpFifo = daemon_local->flags.daemonFifoName;
-    unlink(tmpFifo);
+    if (access(tmpFifo, F_OK) == 0) {
+        dlt_vlog(LOG_WARNING, "FIFO user %s is in use (%s)!\n",
+                 tmpFifo, strerror(errno));
+        return -1;
+    }
 
     ret = mkfifo(tmpFifo, S_IRUSR | S_IWUSR | S_IWGRP);
 
     if (ret == -1) {
         dlt_vlog(LOG_WARNING, "FIFO user %s cannot be created (%s)!\n",
+                 tmpFifo, strerror(errno));
+        return -1;
+    } /* if */
+
+    dir_fd = open(dltFifoBaseDir, O_RDONLY);
+    if (dir_fd == -1) {
+        dlt_vlog(LOG_WARNING, "Directory %s of fifo  cannot be opened (%s)!\n",
+                 dltFifoBaseDir, strerror(errno));
+        return -1;
+    }
+
+    fd = openat(dir_fd, tmpFifo, O_RDWR);
+    if (fd == -1) {
+        dlt_vlog(LOG_WARNING, "FIFO user %s cannot be opened (%s)!\n",
                  tmpFifo, strerror(errno));
         return -1;
     } /* if */
@@ -1608,7 +1627,7 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
         struct group *group_dlt = getgrnam(daemon_local->flags.daemonFifoGroup);
 
         if (group_dlt) {
-            ret = chown(tmpFifo, -1, group_dlt->gr_gid);
+            ret = fchown(fd, -1, group_dlt->gr_gid);
 
             if (ret == -1)
                 dlt_vlog(LOG_ERR, "FIFO user %s cannot be chowned to group %s (%s)\n",
@@ -1627,14 +1646,6 @@ static int dlt_daemon_init_fifo(DltDaemonLocal *daemon_local)
                      strerror(errno));
         }
     }
-
-    fd = open(tmpFifo, O_RDWR);
-
-    if (fd == -1) {
-        dlt_vlog(LOG_WARNING, "FIFO user %s cannot be opened (%s)!\n",
-                 tmpFifo, strerror(errno));
-        return -1;
-    } /* if */
 
 #ifdef __linux__
     /* F_SETPIPE_SZ and F_GETPIPE_SZ are only supported for Linux.


### PR DESCRIPTION
+ Prevent new daemon initialization when using FIFO
+ Unit test gateway IPC changes to UNIX_SOCKET
+ Shared memory is used for multinode testing
+ Resolve the TOCTOU issue