### PR TITLE
dlt-user: fix timeout value of pthread_cond_timedwait() for waiting housekeeper initialization

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -5230,8 +5230,13 @@ int dlt_start_threads()
         * even if we missed the signal
          */
         clock_gettime(CLOCK_MONOTONIC, &now);
-        single_wait.tv_sec = now.tv_sec;
-        single_wait.tv_nsec = now.tv_nsec + 500000000;
+        if (now.tv_nsec >= 500000000) {
+            single_wait.tv_sec = now.tv_sec + 1;
+            single_wait.tv_nsec = now.tv_nsec - 500000000;
+        } else {
+            single_wait.tv_sec = now.tv_sec;
+            single_wait.tv_nsec = now.tv_nsec + 500000000;
+        }
 
         // pthread_cond_timedwait has to be called on a locked mutex
         pthread_mutex_lock(&dlt_housekeeper_running_mutex);


### PR DESCRIPTION
Current implementation just accumulated 500,000,000.
The glibc NPTL pthread_cond_timedwait() implementation return EINVAL if It's  range is not in 0 ~  1,000,000,000..

Here is `pthread_cond_timedwait()` implementation of glibc master branch.
https://github.com/bminor/glibc/blob/9d4b4515a88c5d0bbfc7809374f322c507c2d779/nptl/pthread_cond_wait.c#L633-L636
It calls `valid_nanoseconds()`.
https://github.com/bminor/glibc/blob/9d4b4515a88c5d0bbfc7809374f322c507c2d779/include/time.h#L516-L520

So it makes lots of pthread_cond_timedwait() call with mutex acquire & release when ts.tv_nsec is over 500,000,000.
This commit set proper value for appending 500ms.
