### PR TITLE
Fix usage of gzip_compression

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -1340,14 +1340,13 @@ DLT_STATIC int dlt_logstorage_check_gzip_compression(DltLogStorageFilterConfig *
     } else if (strcasestr(value, "OFF") != NULL) {
         config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
     } else {
-        dlt_log(LOG_WARNING,
-                "Unknown gzip compression flag. Set default OFF\n");
-        config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
+        dlt_log(LOG_WARNING, "Unknown gzip compression flag\n");
+        config->gzip_compression = DLT_LOGSTORAGE_GZIP_ERROR;
         return 1;
     }
 #else
     dlt_log(LOG_WARNING, "dlt-daemon not compiled with logstorage gzip support\n");
-    config->gzip_compression = 0;
+    config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
 #endif
     return 0;
 }

--- a/src/offlinelogstorage/dlt_offline_logstorage.h
+++ b/src/offlinelogstorage/dlt_offline_logstorage.h
@@ -126,8 +126,8 @@
 /* Offline Logstorage disable network routing */
 #define DLT_LOGSTORAGE_GZIP_ERROR               -1 /* error case */
 #define DLT_LOGSTORAGE_GZIP_UNSET                0 /* not set */
-#define DLT_LOGSTORAGE_GZIP_OFF                  1 /* default, enable network routing */
-#define DLT_LOGSTORAGE_GZIP_ON                  (1 << 1) /* disable network routing */
+#define DLT_LOGSTORAGE_GZIP_OFF 1                  /* default, no compression */
+#define DLT_LOGSTORAGE_GZIP_ON (1 << 1)            /* enable gzip compression */
 
 /* logstorage max cache */
 extern unsigned int g_logstorage_cache_max;

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -864,7 +864,7 @@ DLT_STATIC void dlt_logstorage_check_write_ret(DltLogStorageFilterConfig *config
     }
 
     if (ret <= 0) {
-        if (config->== DLT_LOGSTORAGE_GZIP_ON) {
+        if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
             const char *msg = gzerror(config->gzlog, &ret);
             if (msg != NULL) {

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -152,7 +152,7 @@ void dlt_logstorage_log_file_name(char *log_file_name,
     }
 
     dlt_logstorage_concat_logfile_name(log_file_name, ".dlt");
-    if (filter_config->gzip_compression) {
+    if (filter_config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
         dlt_logstorage_concat_logfile_name(log_file_name, ".gz");
     }
 }
@@ -372,7 +372,7 @@ int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
 
     char* suffix = NULL;
     for (i = 0; i < cnt; i++) {
-        if (config->gzip_compression) {
+        if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
             suffix = strdup(".dlt.gz");
         }
         else {
@@ -497,12 +497,13 @@ DLT_STATIC void dlt_logstorage_open_log_output_file(DltLogStorageFilterConfig *c
         return;
     }
     config->fd = fileno(file);
-    if (config->gzip_compression) {
+    if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
         dlt_vlog(LOG_DEBUG, "%s: Opening GZIP log file\n", __func__);
         config->gzlog = gzdopen(config->fd, mode);
 #endif
-    } else {
+    }
+    else {
         dlt_vlog(LOG_DEBUG, "%s: Opening log file\n", __func__);
         config->log = file;
     }
@@ -835,9 +836,10 @@ DLT_STATIC int dlt_logstorage_write_to_log(void *ptr, size_t size, size_t nmemb,
                                            DltLogStorageFilterConfig *config)
 {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
-    if (config->gzip_compression) {
+    if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
         return gzfwrite(ptr, size, nmemb, config->gzlog);
-    } else {
+    }
+    else {
         return fwrite(ptr, size, nmemb, config->log);
     }
 #else
@@ -862,26 +864,28 @@ DLT_STATIC void dlt_logstorage_check_write_ret(DltLogStorageFilterConfig *config
     }
 
     if (ret <= 0) {
-        if (config->gzip_compression) {
+        if (config->== DLT_LOGSTORAGE_GZIP_ON) {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
             const char *msg = gzerror(config->gzlog, &ret);
             if (msg != NULL) {
                 dlt_vlog(LOG_ERR, "%s: failed to write cache into log file: %s\n", __func__, msg);
             }
 #endif
-        } else {
+        }
+        else {
             if (ferror(config->log) != 0)
                 dlt_vlog(LOG_ERR, "%s: failed to write cache into log file\n", __func__);
         }
     }
     else {
         /* force sync */
-        if (config->gzip_compression) {
+        if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
             if (gzflush(config->gzlog, Z_SYNC_FLUSH) != 0)
                 dlt_vlog(LOG_ERR, "%s: failed to gzflush log file\n", __func__);
 #endif
-        } else {
+        }
+        else {
             if (fflush(config->log) != 0)
                 dlt_vlog(LOG_ERR, "%s: failed to flush log file\n", __func__);
         }
@@ -1105,7 +1109,7 @@ int dlt_logstorage_prepare_on_msg(DltLogStorageFilterConfig *config,
                 /* Sync only if on_msg */
                 if ((config->sync == DLT_LOGSTORAGE_SYNC_ON_MSG) ||
                     (config->sync == DLT_LOGSTORAGE_SYNC_UNSET)) {
-                    if (config->gzip_compression) {
+                    if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
                         if (fsync(fileno(config->gzlog)) != 0) {
                             if (errno != ENOSYS) {
                                 dlt_vlog(LOG_ERR, "%s: failed to sync gzip log file\n", __func__);
@@ -1201,10 +1205,11 @@ int dlt_logstorage_write_on_msg(DltLogStorageFilterConfig *config,
         dlt_log(LOG_WARNING, "Wrote less data than specified\n");
 
 #ifdef DLT_LOGSTORAGE_USE_GZIP
-    if (config->gzip_compression) {
+    if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
         gzerror(config->gzlog, &ret);
         return ret;
-    } else {
+    }
+    else {
         return ferror(config->log);
     }
 #else
@@ -1235,12 +1240,13 @@ int dlt_logstorage_sync_on_msg(DltLogStorageFilterConfig *config,
         return -1;
 
     if (status == DLT_LOGSTORAGE_SYNC_ON_MSG) { /* sync on every message */
-        if (config->gzip_compression) {
+        if (config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON) {
 #ifdef DLT_LOGSTORAGE_USE_GZIP
             if (gzflush(config->gzlog, Z_SYNC_FLUSH) != 0)
                 dlt_vlog(LOG_ERR, "%s: failed to gzflush log file\n", __func__);
 #endif
-        } else {
+        }
+        else {
             if (fflush(config->log) != 0)
                 dlt_vlog(LOG_ERR, "%s: failed to flush log file\n", __func__);
         }


### PR DESCRIPTION
If dlt_daemon is compiled with gzip compression any use of GzipCompression will turn it on. This is due to incorrect check of the flag where it is checked as if it was a boolenan when it is an int where only the value DLT_LOGSTORAGE_GZIP_ON means that it should be enabled.