### PR TITLE
Fix file length calculation

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -99,7 +99,9 @@ void dlt_logstorage_log_file_name(char *log_file_name,
         index_width = 0;
     }
 
-    const char * suffix = ".dlt";
+    const char *suffix =
+        ".dlt.gz"; // Unknown here if gzip is used but we assume so as it leads
+                   // to shorter avaialble space
     const int smax = DLT_MOUNT_PATH_MAX - strlen(suffix) - 1;
     int spos = 0;
     log_file_name[spos] = '\0';

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -101,7 +101,7 @@ void dlt_logstorage_log_file_name(char *log_file_name,
 
     const char *suffix =
         ".dlt.gz"; // Unknown here if gzip is used but we assume so as it leads
-                   // to shorter avaialble space
+                   // to shorter available space
     const int smax = DLT_MOUNT_PATH_MAX - strlen(suffix) - 1;
     int spos = 0;
     log_file_name[spos] = '\0';

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -100,8 +100,8 @@ void dlt_logstorage_log_file_name(char *log_file_name,
     }
 
     const char *suffix =
-        ".dlt.gz"; // Unknown here if gzip is used but we assume so as it leads
-                   // to shorter available space
+        filter_config->gzip_compression == DLT_LOGSTORAGE_GZIP_ON ? ".dlt.gz"
+                                                                  : ".dlt";
     const int smax = DLT_MOUNT_PATH_MAX - strlen(suffix) - 1;
     int spos = 0;
     log_file_name[spos] = '\0';


### PR DESCRIPTION
dlt_logstorage_log_file_name assumed the suffix always is .dlt which is not be the case if gzip compression is enabled. Changed to assume .dlt.gz when smax is calculated as it prevents buffer overflow if filenames are long and gzip is enabled.
