### PR TITLE
Enable file compression on file rotation

### DIFF
--- a/doc/dlt_offline_logstorage.md
+++ b/doc/dlt_offline_logstorage.md
@@ -77,7 +77,7 @@ NOFiles=<number of files>            # Number of created files before oldest is 
 SyncBehavior=<strategy>              # Specify sync strategy. Default: Sync'ed after every message. See Logstorage Ringbuffer Implementation below.
 EcuID=<ECUid>                        # Specify ECU identifier
 SpecificSize=<spec size in bytes>    # Store logs in storage devices after specific size is reached.
-GzipCompression=<ON/OFF>             # Write the logfiles with gzip compression.
+GzipCompression=<ON/FILE/OFF>        # Write the logfiles with gzip compression. ON: Continously, FILE: On file rotation
 OverwriteBehavior=<strategy>         # Specify overwrite strategy. Default: Delete oldest file and continue. See Logstorage Ringbuffer Implementation below.
 DisableNetwork=<ON/OFF>              # Specify if the message shall be routed to network client.
 ```

--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -1345,8 +1345,7 @@ DLT_STATIC int dlt_logstorage_check_gzip_compression(DltLogStorageFilterConfig *
         config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
     }
     else {
-        dlt_log(LOG_WARNING,
-                "Unknown gzip compression flag. Set default OFF\n");
+        dlt_log(LOG_WARNING, "Unknown gzip compression flag\n");
         config->gzip_compression = DLT_LOGSTORAGE_GZIP_ERROR;
         return 1;
     }

--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -1337,17 +1337,22 @@ DLT_STATIC int dlt_logstorage_check_gzip_compression(DltLogStorageFilterConfig *
 
     if (strcasestr(value, "ON") != NULL) {
         config->gzip_compression = DLT_LOGSTORAGE_GZIP_ON;
-    } else if (strcasestr(value, "OFF") != NULL) {
+    }
+    else if (strcasestr(value, "FILE") != NULL) {
+        config->gzip_compression = DLT_LOGSTORAGE_GZIP_FILE;
+    }
+    else if (strcasestr(value, "OFF") != NULL) {
         config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
-    } else {
+    }
+    else {
         dlt_log(LOG_WARNING,
                 "Unknown gzip compression flag. Set default OFF\n");
-        config->gzip_compression = DLT_LOGSTORAGE_GZIP_OFF;
+        config->gzip_compression = DLT_LOGSTORAGE_GZIP_ERROR;
         return 1;
     }
 #else
     dlt_log(LOG_WARNING, "dlt-daemon not compiled with logstorage gzip support\n");
-    config->gzip_compression = 0;
+    config->gzip_compression = DLT_LOGSTORAGE_GZIP_ERROR;
 #endif
     return 0;
 }

--- a/src/offlinelogstorage/dlt_offline_logstorage.h
+++ b/src/offlinelogstorage/dlt_offline_logstorage.h
@@ -126,8 +126,11 @@
 /* Offline Logstorage disable network routing */
 #define DLT_LOGSTORAGE_GZIP_ERROR               -1 /* error case */
 #define DLT_LOGSTORAGE_GZIP_UNSET                0 /* not set */
-#define DLT_LOGSTORAGE_GZIP_OFF                  1 /* default, enable network routing */
-#define DLT_LOGSTORAGE_GZIP_ON                  (1 << 1) /* disable network routing */
+#define DLT_LOGSTORAGE_GZIP_OFF 1                  /* default, no compression */
+#define DLT_LOGSTORAGE_GZIP_ON                                                 \
+    (1 << 1) /* enable gzip compression of all files */
+#define DLT_LOGSTORAGE_GZIP_FILE                                               \
+    (1 << 2) /* enable gzip compression on file rotation */
 
 /* logstorage max cache */
 extern unsigned int g_logstorage_cache_max;

--- a/src/offlinelogstorage/dlt_offline_logstorage.h
+++ b/src/offlinelogstorage/dlt_offline_logstorage.h
@@ -123,7 +123,7 @@
 #define DLT_LOGSTORAGE_DISABLE_NW_OFF            1 /* default, enable network routing */
 #define DLT_LOGSTORAGE_DISABLE_NW_ON            (1 << 1) /* disable network routing */
 
-/* Offline Logstorage disable network routing */
+/* Offline Logstorage enable gzip compression */
 #define DLT_LOGSTORAGE_GZIP_ERROR               -1 /* error case */
 #define DLT_LOGSTORAGE_GZIP_UNSET                0 /* not set */
 #define DLT_LOGSTORAGE_GZIP_OFF 1                  /* default, no compression */

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior_internal.h
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior_internal.h
@@ -75,6 +75,10 @@ int dlt_logstorage_open_log_file(DltLogStorageFilterConfig *config,
                                  bool is_update_required,
                                  bool is_sync);
 
+#define COMPRESS_CHUNK 16384
+int dlt_logstorage_compress_dlt_file(char *path);
+int dlt_logstorage_compress_fd(FILE *source, gzFile *dest);
+
 DLT_STATIC int dlt_logstorage_sync_to_file(DltLogStorageFilterConfig *config,
                                            DltLogStorageUserConfig *file_config,
                                            char *dev_path,


### PR DESCRIPTION
Add option to have dlt files compressed on file rotation so the current file stays uncompressed but all other are compressed. This is so all files can be copied without issues as the current file otherwise is likely to be truncated.
