### PR TITLE
Close file after write

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -967,6 +967,7 @@ DLT_STATIC int dlt_logstorage_sync_to_file(DltLogStorageFilterConfig *config,
     }
 
     if (config->skip == 1) {
+        dlt_logstorage_close_file(config);
         return 0;
     }
 
@@ -1015,11 +1016,13 @@ DLT_STATIC int dlt_logstorage_sync_to_file(DltLogStorageFilterConfig *config,
                                              count, true, false) != 0)
             {
                 dlt_vlog(LOG_ERR, "%s: failed to open log file\n", __func__);
+                dlt_logstorage_close_file(config);
                 return -1;
             }
 
             if (config->skip == 1)
             {
+                dlt_logstorage_close_file(config);
                 return 0;
             }
         }
@@ -1032,7 +1035,7 @@ DLT_STATIC int dlt_logstorage_sync_to_file(DltLogStorageFilterConfig *config,
     }
 
     footer->wrap_around_cnt = 0;
-
+    dlt_logstorage_close_file(config);
     return 0;
 }
 


### PR DESCRIPTION
This commit is to avoid keeping the log file open when not needed. That is helpful if it is a gz file as it then can be copied without being truncated. If the file is copied at the very same time as it is being written to it will still be truncated, but with this commit that risk is smaller.