### PR TITLE
Remove free of string litteral

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -370,15 +370,9 @@ int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
         config->records = NULL;
     }
 
-    char* suffix = NULL;
-    for (i = 0; i < cnt; i++) {
-        if (config->gzip_compression) {
-            suffix = strdup(".dlt.gz");
-        }
-        else {
-            suffix = strdup(".dlt");
-        }
+    char *suffix = config->gzip_compression ? ".dlt.gz" : ".dlt";
 
+    for (i = 0; i < cnt; i++) {
         int len = 0;
         len = strlen(file_name);
 
@@ -469,11 +463,6 @@ int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
         free(files[i]);
 
     free(files);
-
-    if (suffix) {
-        free(suffix);
-        suffix = NULL;
-    }
 
     return ret;
 }


### PR DESCRIPTION
To use free on memory not assigned by alloc is undefined behavior and could cause bugs in some systems.

Also move assignment out of for loop.