### PR TITLE
Check gzlog in dlt_logstorage_sync_to_file

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -999,7 +999,11 @@ DLT_STATIC int dlt_logstorage_sync_to_file(DltLogStorageFilterConfig *config,
     if ((start_index >= 0) && (count > 0))
     {
         /* Prepare log file */
+#ifdef DLT_LOGSTORAGE_USE_GZIP
+        if (config->log == NULL && config->gzlog == NULL)
+#else
         if (config->log == NULL)
+#endif
         {
             if (dlt_logstorage_open_log_file(config, file_config, dev_path,
                                              count, true, false) != 0)


### PR DESCRIPTION
Adds check in dlt_logstorage_sync_to_file that gzlog is NULL if the dlt-daemon is compiled with gzip, otherwise that statement will always return true if using gzip-compression on logs.