### PR TITLE
dlt-system: Avoid expensive getpid() syscalls

### DIFF
--- a/include/dlt/dlt_user.h.in
+++ b/include/dlt/dlt_user.h.in
@@ -271,6 +271,7 @@ typedef struct
 #ifdef DLT_TRACE_LOAD_CTRL_ENABLE
     pthread_rwlock_t trace_load_limit_lock;
 #endif
+    pid_t local_pid;            /**< Local DltUser process identifier cache */
 } DltUser;
 
 typedef int (*dlt_injection_callback_id)(uint32_t, void *, uint32_t, void *);


### PR DESCRIPTION
Since glibc 2.25, getpid() no longer caches the PID, instead performing a full syscall every time. This means we're performing a full syscall roundtrip for *every* *single* *log* *message* on the system.

This patch caches the result of getpid() when appropriate, avoiding unnessicary syscalls.