### PR TITLE
Ensure readlink uses correct buffer size in get_exec_name

### DIFF
--- a/src/core_dump_handler/dlt_cdh_context.c
+++ b/src/core_dump_handler/dlt_cdh_context.c
@@ -55,7 +55,7 @@ cdh_status_t get_exec_name(unsigned int p_pid, char *p_exec_name, int p_exec_nam
     memset(l_exe_link, 0, sizeof(l_exe_link));
     snprintf(l_exe_link, sizeof(l_exe_link) - 1, "/proc/%d/exe", p_pid);
 
-    if (readlink(l_exe_link, g_buffer, p_exec_name_maxsize) < 0)
+    if (readlink(l_exe_link, g_buffer, sizeof(g_buffer) - 1) < 0)
         return CDH_NOK;
 
     if ((l_name_ptr = strrchr(g_buffer, '/')) == NULL)


### PR DESCRIPTION
There is an issue with the get_exec_name function where the executable name could be truncated if the total path length exceeded 32 characters.

The readlink function was using p_exec_name_maxsize (32) as the buffer size for the global buffer g_buffer (4096).
When the path to the /proc/[pid]/exe link exceeded 32 characters, readlink truncated the output, causing incorrect or incomplete executable names.

Updated the readlink call to use the buffer size: sizeof(g_buffer) - 1.
This prevents the truncation of the executable path during the readlink operation.
The executable name is still limited to under 32 characters when copied to p_exec_name via:
strncpy(p_exec_name, l_name_ptr + 1, p_exec_name_maxsize - 1);