### PR TITLE
Refactor legacy code to bypass warning - Phase 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,8 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 
-if(${CMAKE_VERSION} VERSION_GREATER "3.20" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20")
-    cmake_policy(SET CMP0115 OLD)
-endif()
 project(automotive-dlt VERSION 2.18.10)
 
 
@@ -190,7 +187,7 @@ if(WITH_DLT_DAEMON_VSOCK_IPC OR WITH_DLT_LIB_VSOCK_IPC)
 endif()
 
 if(NOT DLT_USER_IPC_PATH)
-    set(DLT_USER_IPC_PATH "/tmp")
+    set(DLT_USER_IPC_PATH "/tmp" CACHE STRING "IPC Path for DLT")
 endif()
 
 add_definitions(-DDLT_USER_IPC_PATH="${DLT_USER_IPC_PATH}")

--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -116,7 +116,7 @@ void dlt_client_register_fetch_next_message_callback(bool (*registerd_callback)(
  * @param verbose if set to true verbose information is printed out.
  * @return negative value if there was an error
  */
-int dlt_client_init_port(DltClient *client, int port, int verbose);
+DltReturnValue dlt_client_init_port(DltClient *client, int port, int verbose);
 
 /**
  * Initialising dlt client structure
@@ -196,7 +196,7 @@ DltReturnValue dlt_client_send_log_level(DltClient *client, char *apid, char *ct
  * @param client pointer to dlt client structure
  * @return negative value if there was an error
  */
-int dlt_client_get_log_info(DltClient *client);
+DltReturnValue dlt_client_get_log_info(DltClient *client);
 /**
  * Send an request to get default log level to the dlt daemon
  * @param client pointer to dlt client structure
@@ -208,7 +208,7 @@ DltReturnValue dlt_client_get_default_log_level(DltClient *client);
  * @param client pointer to dlt client structure
  * @return negative value if there was an error
  */
-int dlt_client_get_software_version(DltClient *client);
+DltReturnValue dlt_client_get_software_version(DltClient *client);
 /**
  * Initialise get log info structure
  * @return void

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NOT WITH_DLT_CONSOLE_WO_SBTM)
 endif()
 
 foreach(target IN LISTS TARGET_LIST)
-    set(target_SRCS ${target})
+    set(target_SRCS ${target}.c)
     add_executable(${target} ${target_SRCS})
     target_link_libraries(${target} dlt dlt_control_common_lib)
     set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)

--- a/src/console/CMakeLists.txt
+++ b/src/console/CMakeLists.txt
@@ -13,41 +13,71 @@
 # For further information see http://www.covesa.org/.
 #######
 
-set(dlt_control_common_SRCS ${CMAKE_CURRENT_SOURCE_DIR}/dlt-control-common.c)
-add_library(dlt_control_common_lib STATIC ${dlt_control_common_SRCS})
-target_link_libraries(dlt_control_common_lib dlt ${DLT_JSON_LIBRARY})
+# Control Common Library ======================================================
+set(CONTROL_COMMON_TARGET dlt-control-common)
+set(CONTROL_COMMON_SOURCE "${CMAKE_CURRENT_SOURCE_DIR}/${CONTROL_COMMON_TARGET}.c")
 
-set(TARGET_LIST "")
-
-if (WITH_DLT_CONSOLE_RECEIVE)
-    list(APPEND TARGET_LIST dlt-receive)
+if(NOT EXISTS "${CONTROL_COMMON_SOURCE}")
+    message(FATAL_ERROR "Missing control common source: ${CONTROL_COMMON_SOURCE}")
 endif()
 
-if (WITH_DLT_CONSOLE_CONVERT)
-    list(APPEND TARGET_LIST dlt-convert)
+add_library(dlt_control_common_lib STATIC "${CONTROL_COMMON_SOURCE}")
+target_link_libraries(dlt_control_common_lib PRIVATE dlt ${DLT_JSON_LIBRARY})
+
+# Console Targets Configuration ===============================================
+set(CONSOLE_BASE_TARGETS)
+set(CONSOLE_CONDITIONAL_TARGETS)
+
+## Conditional targets
+if(WITH_DLT_CONSOLE_RECEIVE)
+    list(APPEND CONSOLE_CONDITIONAL_TARGETS dlt-receive)
+endif()
+
+if(WITH_DLT_CONSOLE_CONVERT)
+    list(APPEND CONSOLE_CONDITIONAL_TARGETS dlt-convert)
 endif()
 
 if(NOT WITH_DLT_CONSOLE_WO_CTRL)
     add_subdirectory(logstorage)
-    if (WITH_DLT_CONSOLE_CONTROL)
-        list(APPEND TARGET_LIST dlt-control)
+
+    if(WITH_DLT_CONSOLE_CONTROL)
+        list(APPEND CONSOLE_CONDITIONAL_TARGETS dlt-control)
     endif()
-    if (WITH_DLT_CONSOLE_PASSIVE_NODE_CTRL)
-        list(APPEND TARGET_LIST dlt-passive-node-ctrl)
+
+    if(WITH_DLT_CONSOLE_PASSIVE_NODE_CTRL)
+        list(APPEND CONSOLE_CONDITIONAL_TARGETS dlt-passive-node-ctrl)
     endif()
 endif()
 
 if(NOT WITH_DLT_CONSOLE_WO_SBTM)
-    list(APPEND TARGET_LIST dlt-sortbytimestamp)
+    list(APPEND CONSOLE_CONDITIONAL_TARGETS dlt-sortbytimestamp)
 endif()
 
-foreach(target IN LISTS TARGET_LIST)
-    set(target_SRCS ${target}.c)
-    add_executable(${target} ${target_SRCS})
-    target_link_libraries(${target} dlt dlt_control_common_lib)
-    set_target_properties(${target} PROPERTIES LINKER_LANGUAGE C)
+# Combine all console targets
+set(CONSOLE_TARGETS_ALL
+    ${CONSOLE_BASE_TARGETS}
+    ${CONSOLE_CONDITIONAL_TARGETS}
+)
 
-    install(TARGETS ${target}
-            RUNTIME DESTINATION bin
-            COMPONENT base)
+# Console Target Construction =================================================
+foreach(CONSOLE_TARGET IN LISTS CONSOLE_TARGETS_ALL)
+    # Source file validation
+    set(SOURCE_FILE "${CONSOLE_TARGET}.c")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE}")
+        message(FATAL_ERROR "Missing console source: ${SOURCE_FILE}")
+    endif()
+
+    # Target configuration
+    add_executable(${CONSOLE_TARGET} "${SOURCE_FILE}")
+    target_link_libraries(${CONSOLE_TARGET} PRIVATE
+        dlt
+        dlt_control_common_lib
+    )
+    set_target_properties(${CONSOLE_TARGET} PROPERTIES LINKER_LANGUAGE C)
+
+    # Installation
+    install(TARGETS ${CONSOLE_TARGET}
+        RUNTIME DESTINATION bin
+        COMPONENT base
+    )
 endforeach()

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -13,101 +13,88 @@
 # For further information see http://www.covesa.org/.
 #######
 
+# Source Configuration ========================================================
+set(BASE_SRC_DIR "${PROJECT_SOURCE_DIR}/src")
 
-if(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
-    message(STATUS "Added ${systemd_SRCS} to dlt-daemon")
-endif()
+# Target Configuration ========================================================
+## Daemon core targets
+set(DLT_DAEMON_CORE_TARGETS
+    dlt-daemon
+    dlt_daemon_client
+    dlt_daemon_common
+    dlt_daemon_connection
+    dlt_daemon_event_handler
+    dlt_daemon_offline_logstorage
+    dlt_daemon_serial
+    dlt_daemon_socket
+    dlt_daemon_unix_socket
+)
 
-set(dlt_daemon_SRCS
-    dlt-daemon.c
-    dlt_daemon_client.c
-    dlt_daemon_common.c
-    dlt_daemon_connection.c
-    dlt_daemon_event_handler.c
-    dlt_daemon_offline_logstorage.c
-    dlt_daemon_serial.c
-    dlt_daemon_socket.c
-    dlt_daemon_unix_socket.c
-    ${PROJECT_SOURCE_DIR}/src/gateway/dlt_gateway.c
-    ${PROJECT_SOURCE_DIR}/src/lib/dlt_client.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_common.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_config_file_parser.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_log.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_multiple_files.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_offline_trace.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_protocol.c
-    ${PROJECT_SOURCE_DIR}/src/shared/dlt_user_shared.c
-    ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage.c
-    ${PROJECT_SOURCE_DIR}/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
-    )
+## Shared component targets
+set(DLT_SHARED_COMPONENT_TARGETS
+    gateway/dlt_gateway
+    lib/dlt_client
+    shared/dlt_common
+    shared/dlt_config_file_parser
+    shared/dlt_log
+    shared/dlt_multiple_files
+    shared/dlt_offline_trace
+    shared/dlt_protocol
+    shared/dlt_user_shared
+    offlinelogstorage/dlt_offline_logstorage
+    offlinelogstorage/dlt_offline_logstorage_behavior
+)
 
+# Source Resolution ===========================================================
+## Convert targets to source files
+foreach(TARGET_NAME IN LISTS DLT_DAEMON_CORE_TARGETS)
+    set(SRC_FILE "${TARGET_NAME}.c")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SRC_FILE}")
+        message(FATAL_ERROR "Missing core source: ${SRC_FILE}")
+    endif()
+    list(APPEND DLT_DAEMON_CORE_SOURCES "${SRC_FILE}")
+endforeach()
+
+foreach(COMPONENT IN LISTS DLT_SHARED_COMPONENT_TARGETS)
+    set(SRC_FILE "${BASE_SRC_DIR}/${COMPONENT}.c")
+    if(NOT EXISTS "${SRC_FILE}")
+        message(FATAL_ERROR "Missing shared component: ${SRC_FILE}")
+    endif()
+    list(APPEND DLT_SHARED_COMPONENTS "${SRC_FILE}")
+endforeach()
+
+# Main Executable Configuration ===============================================
+add_executable(dlt-daemon)
+
+## Core sources
+target_sources(dlt-daemon PRIVATE
+    ${DLT_DAEMON_CORE_SOURCES}
+    ${DLT_SHARED_COMPONENTS}
+    ${systemd_SRCS}
+)
+
+# Optional Components =========================================================
+## Shared Memory Support
 if(WITH_DLT_SHM_ENABLE)
-    set(dlt_daemon_SRCS
-        ${dlt_daemon_SRCS}
-        ${PROJECT_SOURCE_DIR}/src/shared/dlt_shm.c)
+    set(SHM_TARGET "shared/dlt_shm")
+    set(SHM_SOURCE "${BASE_SRC_DIR}/${SHM_TARGET}.c")
+    if(NOT EXISTS "${SHM_SOURCE}")
+        message(FATAL_ERROR "Missing SHM source: ${SHM_SOURCE}")
+    endif()
+    target_sources(dlt-daemon PRIVATE "${SHM_SOURCE}")
 endif()
 
-if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux|CYGWIN|MSYS")
-    set(RT_LIBRARY rt)
-    set(SOCKET_LIBRARY "")
-else()
-    set(RT_LIBRARY "")
-    set(SOCKET_LIBRARY socket)
-endif()
-
+## UDP Connection Support
 if(WITH_UDP_CONNECTION)
-    include_directories(${PROJECT_SOURCE_DIR}/src/daemon/udp_connection)
-    add_definitions(-DUDP_CONNECTION_SUPPORT)
-    set(dlt_daemon_SRCS ${dlt_daemon_SRCS} ${PROJECT_SOURCE_DIR}/src/daemon/udp_connection/dlt_daemon_udp_socket.c)
-endif(WITH_UDP_CONNECTION)
+    set(UDP_TARGET "daemon/udp_connection/dlt_daemon_udp_socket")
+    set(UDP_SOURCE "${BASE_SRC_DIR}/${UDP_TARGET}.c")
+    if(NOT EXISTS "${UDP_SOURCE}")
+        message(FATAL_ERROR "Missing UDP source: ${UDP_SOURCE}")
+    endif()
 
-add_executable(dlt-daemon ${dlt_daemon_SRCS} ${systemd_SRCS})
-target_link_libraries(dlt-daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-if (WITH_SYSTEMD_SOCKET_ACTIVATION)
-    target_link_libraries(dlt-daemon systemd)
-endif()
-if (WITH_DLT_LOGSTORAGE_GZIP)
-	target_link_libraries(dlt-daemon ${ZLIB_LIBRARY})
-endif()
-
-install(TARGETS dlt-daemon
-        RUNTIME DESTINATION bin
-        PERMISSIONS
-            OWNER_EXECUTE OWNER_WRITE OWNER_READ
-            GROUP_EXECUTE GROUP_READ
-            WORLD_EXECUTE WORLD_READ
-        COMPONENT base)
-
-if (WITH_DLT_UNIT_TESTS)
-    set(library_SRCS ${dlt_daemon_SRCS})
-
-    if (WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
-        set(library_SRCS ${library_SRCS} ${systemd_SRCS})
-    endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
-
-    add_library(dlt_daemon ${library_SRCS})
-    target_compile_definitions(dlt_daemon PRIVATE DLT_USER_IPC_PATH="${DLT_USER_IPC_PATH}")
-    target_link_libraries(dlt_daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
-
-    install(TARGETS dlt_daemon
-            RUNTIME DESTINATION bin
-            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}/static
-            COMPONENT base)
-endif(WITH_DLT_UNIT_TESTS)
-
-INSTALL(FILES dlt.conf
-	DESTINATION ${CONFIGURATION_FILES_DIR}
-	COMPONENT base)
-
-if (WITH_DLT_LOG_LEVEL_APP_CONFIG)
-    INSTALL(FILES dlt-log-levels.conf
-            DESTINATION ${CONFIGURATION_FILES_DIR}
-            COMPONENT base)
-endif()
-
-if (WITH_DLT_TRACE_LOAD_CTRL)
-    INSTALL(FILES dlt-trace-load.conf
-            DESTINATION ${CONFIGURATION_FILES_DIR}
-            COMPONENT base)
+    target_include_directories(dlt-daemon PRIVATE
+        ${BASE_SRC_DIR}/daemon/udp_connection
+    )
+    target_compile_definitions(dlt-daemon PRIVATE UDP_CONNECTION_SUPPORT)
+    target_sources(dlt-daemon PRIVATE "${UDP_SOURCE}")
 endif()

--- a/src/daemon/CMakeLists.txt
+++ b/src/daemon/CMakeLists.txt
@@ -86,6 +86,7 @@ if (WITH_DLT_UNIT_TESTS)
     endif(WITH_SYSTEMD_WATCHDOG OR WITH_SYSTEMD)
 
     add_library(dlt_daemon ${library_SRCS})
+    target_compile_definitions(dlt_daemon PRIVATE DLT_USER_IPC_PATH="${DLT_USER_IPC_PATH}")
     target_link_libraries(dlt_daemon ${RT_LIBRARY} ${SOCKET_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
 
     install(TARGETS dlt_daemon

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -726,10 +726,19 @@ DltDaemonApplication *dlt_daemon_application_add(DltDaemon *daemon,
         }
 #endif
 #ifdef DLT_DAEMON_USE_FIFO_IPC
+        /* /dltpipes/dlt%d consists of 13 bytes "/dltpipes/dlt" and pid field (INT_MAX = 2147483647 - 32 bit)
+         * The worst case: "/dltpipes/dlt2147483647"
+         * Total: 13 + 4 + '\0' = 18 bytes
+         * DLT_DAEMON_COMMON_TEXTBUFSIZE = 255 bytes
+         * Space left: 255 - 18 = 237 bytes
+         */
+        const size_t overhead = strlen("/dltpipes/dlt") + sizeof(int) + 1;
+        const size_t max_base_dir_len = DLT_DAEMON_COMMON_TEXTBUFSIZE - overhead;
         if (dlt_user_handle < DLT_FD_MINIMUM) {
             snprintf(filename,
                      DLT_DAEMON_COMMON_TEXTBUFSIZE,
-                     "%s/dltpipes/dlt%d",
+                     "%.*s/dltpipes/dlt%d",
+                     (int)max_base_dir_len,
                      dltFifoBaseDir,
                      pid);
 

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WITH_UDP_CONNECTION)
 endif()
 
 foreach(TARGET IN LISTS TARGET_LIST)
-    set(TARGET_SRCS ${TARGET})
+    set(TARGET_SRCS ${TARGET}.c)
     add_executable(${TARGET} ${TARGET_SRCS})
     target_link_libraries(${TARGET} dlt)
     set_target_properties(${TARGET} PROPERTIES LINKER_LANGUAGE C)

--- a/src/examples/CMakeLists.txt
+++ b/src/examples/CMakeLists.txt
@@ -13,23 +13,52 @@
 # For further information see http://www.covesa.org/.
 #######
 
-set(TARGET_LIST dlt-example-user-func)
-set(TARGET_LIST ${TARGET_LIST} dlt-example-filetransfer)
+# Example targets configuration ===============================================
+# Base example targets
+set(EXAMPLE_BASE_TARGETS
+    dlt-example-user-func
+    dlt-example-filetransfer
+)
+
+# Conditional example targets
+set(EXAMPLE_CONDITIONAL_TARGETS)
 if(NOT WITH_DLT_DISABLE_MACRO)
-    set(TARGET_LIST ${TARGET_LIST} dlt-example-user)
-    set(TARGET_LIST ${TARGET_LIST} dlt-example-user-common-api)
+    list(APPEND EXAMPLE_CONDITIONAL_TARGETS
+        dlt-example-user
+        dlt-example-user-common-api
+    )
 endif()
 
 if(WITH_UDP_CONNECTION)
-    set(TARGET_LIST ${TARGET_LIST} dlt-example-multicast-clientmsg-view)
+    list(APPEND EXAMPLE_CONDITIONAL_TARGETS
+        dlt-example-multicast-clientmsg-view
+    )
 endif()
 
-foreach(TARGET IN LISTS TARGET_LIST)
-    set(TARGET_SRCS ${TARGET}.c)
-    add_executable(${TARGET} ${TARGET_SRCS})
-    target_link_libraries(${TARGET} dlt)
-    set_target_properties(${TARGET} PROPERTIES LINKER_LANGUAGE C)
-    install(TARGETS ${TARGET}
-            RUNTIME DESTINATION bin
-            COMPONENT base)
+# Combine all example targets
+set(EXAMPLE_TARGETS_ALL
+    ${EXAMPLE_BASE_TARGETS}
+    ${EXAMPLE_CONDITIONAL_TARGETS}
+)
+
+# Example target construction =================================================
+foreach(EXAMPLE_TARGET IN LISTS EXAMPLE_TARGETS_ALL)
+    # Source file validation
+    set(SOURCE_FILE "${EXAMPLE_TARGET}.c")
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${SOURCE_FILE}")
+        message(FATAL_ERROR "Missing C source for ${EXAMPLE_TARGET} - ${SOURCE_FILE} not found")
+    endif()
+
+    # Target creation
+    add_executable(${EXAMPLE_TARGET} ${SOURCE_FILE})
+
+    # Dependencies and properties
+    target_link_libraries(${EXAMPLE_TARGET} PRIVATE dlt)
+    set_target_properties(${EXAMPLE_TARGET} PROPERTIES LINKER_LANGUAGE C)
+
+    # Installation
+    install(TARGETS ${EXAMPLE_TARGET}
+        RUNTIME DESTINATION bin
+        COMPONENT base
+    )
 endforeach()

--- a/src/gateway/dlt_gateway.c
+++ b/src/gateway/dlt_gateway.c
@@ -1610,7 +1610,7 @@ int dlt_gateway_forward_control_message(DltGateway *gateway,
 
 int dlt_gateway_process_on_demand_request(DltGateway *gateway,
                                           DltDaemonLocal *daemon_local,
-                                          char node_id[DLT_ID_SIZE],
+                                          char *node_id,
                                           int connection_status,
                                           int verbose)
 {

--- a/src/gateway/dlt_gateway.h
+++ b/src/gateway/dlt_gateway.h
@@ -112,7 +112,7 @@ DltReceiver *dlt_gateway_get_connection_receiver(DltGateway *g, int fd);
  * @param verbose verbose flag
  * @return 0 on success, -1 otherwise
  */
-int dlt_gateway_process_passive_node_messages(DltDaemon *daemon,
+DltReturnValue dlt_gateway_process_passive_node_messages(DltDaemon *daemon,
                                               DltDaemonLocal *daemon_local,
                                               DltReceiver *recv,
                                               int verbose);

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -2304,7 +2304,7 @@ void dlt_buffer_read_block(DltBuffer *buf, int *read, unsigned char *data, unsig
     }
 }
 
-int dlt_buffer_check_size(DltBuffer *buf, int needed)
+DltReturnValue dlt_buffer_check_size(DltBuffer *buf, int needed)
 {
     if (buf == NULL)
         return DLT_RETURN_WRONG_PARAMETER;
@@ -2456,7 +2456,7 @@ DltReturnValue dlt_buffer_push(DltBuffer *buf, const unsigned char *data, unsign
     return dlt_buffer_push3(buf, data, size, 0, 0, 0, 0);
 }
 
-int dlt_buffer_push3(DltBuffer *buf,
+DltReturnValue dlt_buffer_push3(DltBuffer *buf,
                      const unsigned char *data1,
                      unsigned int size1,
                      const unsigned char *data2,

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,33 +13,33 @@
 # For further information see http://www.covesa.org/.
 #######
 
-set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process-client)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-user)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-client)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-user)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-client)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-fork-handler)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-init-free)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-preregister-context)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-filetransfer)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process-client.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-user.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-client.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-user.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-client.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-stress.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-fork-handler.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-init-free.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-preregister-context.c)
+set(TARGET_LIST ${TARGET_LIST} dlt-test-filetransfer.c)
 install(FILES dlt-test-filetransfer-file dlt-test-filetransfer-image.png
         DESTINATION share/dlt-filetransfer)
 
 if(WITH_DLT_CXX11_EXT)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-cpp-extension)
+    set(TARGET_LIST ${TARGET_LIST} dlt-test-cpp-extension.cpp)
 endif()
 
 #TODO: Enable again once dlt-test-non-verbose is adapted to non-macro usage
 if (NOT WITH_DLT_DISABLE_MACRO)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-non-verbose)
+    set(TARGET_LIST ${TARGET_LIST} dlt-test-non-verbose.c)
 endif()
 
 if(WITH_DLT_QNX_SYSTEM)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-qnx-slogger)
+    set(TARGET_LIST ${TARGET_LIST} dlt-test-qnx-slogger.c)
 endif()
- 
+
 foreach(TARGET IN LISTS TARGET_LIST)
     set(TARGET_SRCS ${TARGET})
     add_executable(${TARGET} ${TARGET_SRCS})

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -13,39 +13,79 @@
 # For further information see http://www.covesa.org/.
 #######
 
-set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-multi-process-client.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-user.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-client.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-user.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress-client.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-stress.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-fork-handler.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-init-free.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-preregister-context.c)
-set(TARGET_LIST ${TARGET_LIST} dlt-test-filetransfer.c)
-install(FILES dlt-test-filetransfer-file dlt-test-filetransfer-image.png
-        DESTINATION share/dlt-filetransfer)
+# Test target configuration ===================================================
+# Base test targets
+set(TEST_BASE_TARGETS
+    dlt-test-multi-process
+    dlt-test-multi-process-client
+    dlt-test-user
+    dlt-test-client
+    dlt-test-stress-user
+    dlt-test-stress-client
+    dlt-test-stress
+    dlt-test-fork-handler
+    dlt-test-init-free
+    dlt-test-preregister-context
+    dlt-test-filetransfer
+)
 
+# Conditional test targets
+set(TEST_CONDITIONAL_TARGETS)
 if(WITH_DLT_CXX11_EXT)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-cpp-extension.cpp)
+    list(APPEND TEST_CONDITIONAL_TARGETS dlt-test-cpp-extension)
 endif()
 
-#TODO: Enable again once dlt-test-non-verbose is adapted to non-macro usage
-if (NOT WITH_DLT_DISABLE_MACRO)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-non-verbose.c)
+if(NOT WITH_DLT_DISABLE_MACRO)
+    list(APPEND TEST_CONDITIONAL_TARGETS dlt-test-non-verbose)
 endif()
 
 if(WITH_DLT_QNX_SYSTEM)
-    set(TARGET_LIST ${TARGET_LIST} dlt-test-qnx-slogger.c)
+    list(APPEND TEST_CONDITIONAL_TARGETS dlt-test-qnx-slogger)
 endif()
 
-foreach(TARGET IN LISTS TARGET_LIST)
-    set(TARGET_SRCS ${TARGET})
-    add_executable(${TARGET} ${TARGET_SRCS})
-    target_link_libraries(${TARGET} dlt)
-    set_target_properties(${TARGET} PROPERTIES LINKER_LANGUAGE C)
-    install(TARGETS ${TARGET}
-            RUNTIME DESTINATION bin
-            COMPONENT base)
+# Combine all test targets
+set(TEST_TARGETS_ALL
+    ${TEST_BASE_TARGETS}
+    ${TEST_CONDITIONAL_TARGETS}
+)
+
+# File installation configuration
+set(TEST_DATA_FILES
+    dlt-test-filetransfer-file
+    dlt-test-filetransfer-image.png
+)
+
+install(FILES ${TEST_DATA_FILES}
+    DESTINATION share/dlt-filetransfer
+)
+
+# Test target construction ====================================================
+foreach(TEST_TARGET IN LISTS TEST_TARGETS_ALL)
+    # Source file resolution
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_TARGET}.c")
+        set(SOURCE_FILE "${TEST_TARGET}.c")
+    elseif(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${TEST_TARGET}.cpp")
+        set(SOURCE_FILE "${TEST_TARGET}.cpp")
+    else()
+        message(FATAL_ERROR "Missing source for ${TEST_TARGET} - checked .c and .cpp extensions")
+    endif()
+
+    # Target creation
+    add_executable(${TEST_TARGET} ${SOURCE_FILE})
+
+    # Language configuration
+    if(SOURCE_FILE MATCHES "\\.cpp$")
+        set_target_properties(${TEST_TARGET} PROPERTIES LINKER_LANGUAGE CXX)
+    else()
+        set_target_properties(${TEST_TARGET} PROPERTIES LINKER_LANGUAGE C)
+    endif()
+
+    # Dependencies
+    target_link_libraries(${TEST_TARGET} PRIVATE dlt)
+
+    # Installation
+    install(TARGETS ${TEST_TARGET}
+        RUNTIME DESTINATION bin
+        COMPONENT base
+    )
 endforeach()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,18 @@
+#######
+# SPDX license identifier: MPL-2.0
+#
+# Copyright (C) 2011-2015, BMW AG
+#
+# This file is part of COVESA Project DLT - Diagnostic Log and Trace.
+#
+# This Source Code Form is subject to the terms of the
+# Mozilla Public License (MPL), v. 2.0.
+# If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# For further information see http://www.covesa.org/.
+#######
+
 SET(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -isystem ${gtest_SOURCE_DIR}/include")
 SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -isystem ${gtest_SOURCE_DIR}/include -std=gnu++0x")
 
@@ -70,7 +85,7 @@ set(TARGET_LIST gtest_dlt_common
                 dlt_env_ll_unit_test)
 
 foreach(target IN LISTS TARGET_LIST)
-    set(target_SRCS ${target})
+    set(target_SRCS ${target}.cpp)
     if(${target} STREQUAL "gtest_dlt_daemon_common")
         set(target_SRCS ${target_SRCS} ${PROJECT_SOURCE_DIR}/src/daemon/dlt_daemon_common.c)
     elseif(${target} STREQUAL "gtest_dlt_daemon")
@@ -128,7 +143,7 @@ if(WITH_DLT_SHM_ENABLE)
 endif()
 
 foreach(target IN LISTS TARGET_LIST)
-    set(target_SRCS ${target})
+    set(target_SRCS ${target}.cpp)
     add_executable(${target} ${target_SRCS} ${systemd_SRCS})
     target_link_libraries(${target} ${DLT_DAEMON_LIBRARIES} ${ZLIB_LIBRARY})
     if(WITH_DLT_INSTALLED_TESTS)


### PR DESCRIPTION
--------------------------------------------------------
cmake: satisfying CMP0115
--------------------------------------------------------
Since CMake 3.20, CMake prefers all source files to
have their extensions explicitly listed. File extensions
*.c and *.cpp are added to CMakeLists.txt.

Update minimum cmake version to 3.10

--------------------------------------------------------
lib, shared, daemon, gateway: refactor legacy code
--------------------------------------------------------
dlt_user: recalculate exact path length buffers
dlt_client: correct function type
dlt_common: correct function type
dlt_multiple_files: recalculate buffer file name
dlt_daemon: recalculate exact path length buffers
dlt_daemon_common: recalculate exact path length buffers
dlt_gateway: correct function type, correct arg type