### PR TITLE
Revert "dlt-daemon: Handle partial message parsing in receiver buffer"

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -3883,17 +3883,6 @@ int dlt_daemon_process_user_message_log(DltDaemon *daemon,
              * or the headers are corrupted (error case). */
             dlt_log(LOG_DEBUG, "Can't read messages from receiver\n");
 
-        if (dlt_receiver_remove(rec, rec->bytesRcvd) != DLT_RETURN_OK) {
-            /* In certain rare scenarios where only a partial message has been received
-             * (Eg: kernel IPC buffer memory being full), we want to discard the message
-             * and not broadcast it forward to connected clients. Since the DLT library
-             * checks return value of the writev() call against the sent total message
-             * length, the partial message will be buffered and retransmitted again.
-             * This implicitly ensures that no message loss occurs.
-             */
-            dlt_log(LOG_WARNING, "failed to remove required bytes from receiver.\n");
-        }
-
         return DLT_DAEMON_ERROR_UNKNOWN;
     }
 


### PR DESCRIPTION
This reverts commit 1737de27825c691e925a7d42abe34311159c48c6.

The original commit aimed to address potential partial message reception. However, this issue is not observed on Linux and QNX systems, which are the primary target platforms for dlt-daemon. Furthermore, the changes introduced by the reverted commit have been found to cause message loss in certain scenarios.
Therefore, to ensure the stability and reliability of dlt-daemon, this commit reverts the problematic changes.

This revert addresses issue #631.