### PR TITLE
fix file-rotation-failure-in-offline-storage

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -1760,6 +1760,7 @@ DLT_STATIC int dlt_daemon_offline_setup_filter_properties(DltLogStorage *handle,
     tmp_data.log_level = DLT_LOG_VERBOSE;
     tmp_data.reset_log_level = DLT_LOG_OFF;
     tmp_data.disable_network_routing = DLT_LOGSTORAGE_DISABLE_NW_OFF;
+    tmp_data.fd = -1;
 
     for (i = 0; i < DLT_LOGSTORAGE_FILTER_CONF_COUNT; i++) {
         ret = dlt_logstorage_get_filter_value(config_file, sec_name, i, value);

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -614,7 +614,8 @@ int dlt_logstorage_open_log_file(DltLogStorageFilterConfig *config,
          * is_sync is true and (other than ON_MSG sync behavior and current size is less than configured size) or
          * msg_size fit into the size (ON_MSG or par of cache needs to be written into new file), open it */
         if ((ret == 0) &&
-            ((is_sync && (s.st_size < (int)config->file_size)) ||
+            ((config->fd == -1) ||
+             (is_sync && (s.st_size < (int)config->file_size)) ||
              (!is_sync && (s.st_size + msg_size <= (int)config->file_size)))) {
             dlt_logstorage_open_log_output_file(config, absolute_file_path, "a");
             config->current_write_file_offset = s.st_size;


### PR DESCRIPTION
## Description
Fixes a bug where the dlt-daemon fails to rotate log files in offline storage mode due to fd unavailable.

## Issue Manifestation
- During initial storage, when no log files exist in the designated directory, rotation occurs correctly as configured in dlt_logstorage.conf
- Upon device reboot, when historical log files are present in the storage directory, there exists a probability of rotation failure, resulting in indefinite growth of a single file. The failure probability exhibits an inverse correlation with the FileSize parameter configured in the filter.

## Trigger Conditions
- When writing the first log message after device reboot, if the combined size of the most recent historical log file and the current message exceeds the configured file size threshold
### Example scenario:
- Config->FileSize: 1000
- LatestFileSize: 900
- LogMessage: 110

## Root Cause
The file handle acquisition function fails to execute, leaving the file handle with its default invalid value.