### PR TITLE
Fix occasional dlt-daemon hanging when client process exits on QNX

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -30,8 +30,7 @@ cc_defaults {
         "-DDLT_LIB_USE_UNIX_SOCKET_IPC",
         "-DCONFIGURATION_FILES_DIR=\"/vendor/etc\"",
         "-DDLT_USER_IPC_PATH=\"/dev/socket\"",
-        "-DDLT_WRITEV_TIMEOUT_SEC=1",
-        "-DDLT_WRITEV_TIMEOUT_USEC=0",
+        "-DDLT_WRITEV_TIMEOUT_MS=1000",
     ] + [
         "-Wno-unused-parameter",
         "-W",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,10 +124,8 @@ option(WITH_DLT_LIB_VSOCK_IPC "Set to ON to enable VSOCK support in library (DLT
 
 set(DLT_VSOCK_PORT "13490"
     CACHE STRING "VSOCK port number for logging traffic.")
-set(DLT_WRITEV_TIMEOUT_SEC "1"
-    CACHE STRING "Set sec timeout for writev to prevent blocking indefinitely")
-set(DLT_WRITEV_TIMEOUT_USEC "0"
-    CACHE STRING "Set usec timeout for writev to prevent blocking indefinitely")
+set(DLT_WRITEV_TIMEOUT_MS "1000"
+    CACHE STRING "Set millisecond timeout for writev to prevent blocking indefinitely")
 
 # RPM settings
 set(COVESA_RPM_RELEASE "1")  # ${DLT_REVISION}
@@ -165,8 +163,7 @@ include_directories(
 )
 
 add_definitions(-D_GNU_SOURCE)
-add_definitions(-DDLT_WRITEV_TIMEOUT_SEC=${DLT_WRITEV_TIMEOUT_SEC})
-add_definitions(-DDLT_WRITEV_TIMEOUT_USEC=${DLT_WRITEV_TIMEOUT_USEC})
+add_definitions(-DDLT_WRITEV_TIMEOUT_MS=${DLT_WRITEV_TIMEOUT_MS})
 add_definitions(-DDLT_QNX_SLOG_ADAPTER_WAIT_BUFFER_TIMEOUT_MS=${DLT_QNX_SLOG_ADAPTER_WAIT_BUFFER_TIMEOUT_MS})
 
 if(NOT DLT_IPC STREQUAL "UNIX_SOCKET" AND NOT DLT_IPC STREQUAL "FIFO")

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -1725,7 +1725,7 @@ int dlt_daemon_user_send_log_level(DltDaemon *daemon, DltDaemonContext *context,
                  __func__,
                  errno != 0 ? strerror(errno) : "Unknown error");
 
-        if (errno == EPIPE) {
+        if (errno == EPIPE || errno == EBADF) {
             app = dlt_daemon_application_find(daemon, context->apid, daemon->ecuid, verbose);
             if (app != NULL)
                 dlt_daemon_application_reset_user_handle(daemon, app, verbose);
@@ -1757,7 +1757,7 @@ int dlt_daemon_user_send_log_state(DltDaemon *daemon, DltDaemonApplication *app,
                             &(logstate), sizeof(DltUserControlMsgLogState));
 
     if (ret < DLT_RETURN_OK) {
-        if (errno == EPIPE)
+        if (errno == EPIPE || errno == EBADF)
             dlt_daemon_application_reset_user_handle(daemon, app, verbose);
     }
 
@@ -2084,8 +2084,9 @@ int dlt_daemon_user_send_trace_load_config(DltDaemon *const daemon, DltDaemonApp
                                          &(trace_load_settings_count), sizeof(uint32_t),
                                          trace_load_settings_user_msg, sizeof(DltUserControlMsgTraceSettingMsg) * trace_load_settings_count);
 
-    if (ret < DLT_RETURN_OK && errno == EPIPE) {
-        dlt_daemon_application_reset_user_handle(daemon, app, verbose);
+    if (ret < DLT_RETURN_OK) {
+        if (errno == EPIPE || errno == EBADF)
+            dlt_daemon_application_reset_user_handle(daemon, app, verbose);
     }
 
     free(trace_load_settings_user_msg);

--- a/src/shared/dlt_user_shared.c
+++ b/src/shared/dlt_user_shared.c
@@ -69,9 +69,9 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <poll.h>
 
 #include <sys/uio.h> /* writev() */
-#include <sys/time.h> /* timeval */
 
 #include "dlt_user_shared.h"
 #include "dlt_user_shared_cfg.h"
@@ -132,16 +132,15 @@ DltReturnValue dlt_user_log_out2_with_timeout(int handle, void *ptr1, size_t len
         /* Invalid handle */
         return DLT_RETURN_ERROR;
 
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(handle, &fds);
+    struct pollfd pfd;
+    pfd.fd = handle;
+    pfd.events = POLLOUT;
 
-    struct timeval tv = { DLT_WRITEV_TIMEOUT_SEC, DLT_WRITEV_TIMEOUT_USEC };
-    if (select(handle+1, NULL, &fds, NULL, &tv) < 0) {
+    if (poll(&pfd, 1, DLT_WRITEV_TIMEOUT_MS) < 0) {
         return DLT_RETURN_ERROR;
     }
 
-    if (FD_ISSET(handle, &fds)) {
+    if (pfd.revents & POLLOUT) {
         return dlt_user_log_out2(handle, ptr1, len1, ptr2, len2);
     } else {
         return DLT_RETURN_ERROR;
@@ -206,16 +205,15 @@ DltReturnValue dlt_user_log_out3_with_timeout(int handle, void *ptr1, size_t len
         /* Invalid handle */
         return DLT_RETURN_ERROR;
 
-    fd_set fds;
-    FD_ZERO(&fds);
-    FD_SET(handle, &fds);
+    struct pollfd pfd;
+    pfd.fd = handle;
+    pfd.events = POLLOUT;
 
-    struct timeval tv = { DLT_WRITEV_TIMEOUT_SEC, DLT_WRITEV_TIMEOUT_USEC };
-    if (select(handle+1, NULL, &fds, NULL, &tv) < 0) {
+    if (poll(&pfd, 1, DLT_WRITEV_TIMEOUT_MS) < 0) {
         return DLT_RETURN_ERROR;
     }
 
-    if (FD_ISSET(handle, &fds)) {
+    if (pfd.revents & POLLOUT) {
         return dlt_user_log_out3(handle, ptr1, len1, ptr2, len2, ptr3, len3);
     } else {
         return DLT_RETURN_ERROR;


### PR DESCRIPTION
Problem: dlt-daemon occasionally freezes on QNX when client processes exit unexpectedly

Cause: Socket errors return EBADF but only EPIPE is handled, and select() blocks indefinitely despite timeout (likely a QNX-specific issue)

Fix:
* Add EBADF error handling alongside EPIPE to properly close invalid sockets
* Replace select() with poll() for improved timeout handling efficiency in log output functions