### PR TITLE
cmake: Set minimum required version to 3.5 for CMake 4+ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.20" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20")
     cmake_policy(SET CMP0115 OLD)

--- a/examples/example1/CMakeLists.txt
+++ b/examples/example1/CMakeLists.txt
@@ -17,7 +17,7 @@
 # DLT example implementation
 #
 
-cmake_minimum_required( VERSION 2.6 )
+cmake_minimum_required( VERSION 3.5 )
 project( automotive-dlt-example1 )
 
 #

--- a/examples/example2/CMakeLists.txt
+++ b/examples/example2/CMakeLists.txt
@@ -17,7 +17,7 @@
 # DLT example implementation
 #
 
-cmake_minimum_required( VERSION 2.6 )
+cmake_minimum_required( VERSION 3.5 )
 project( automotive-dlt-example2 )
 
 #

--- a/examples/example3/CMakeLists.txt
+++ b/examples/example3/CMakeLists.txt
@@ -17,7 +17,7 @@
 # DLT example implementation
 #
 
-cmake_minimum_required( VERSION 2.6 )
+cmake_minimum_required( VERSION 3.5 )
 project( automotive-dlt-example3 )
 
 #

--- a/examples/example4/CMakeLists.txt
+++ b/examples/example4/CMakeLists.txt
@@ -17,7 +17,7 @@
 # DLT example implementation
 #
 
-cmake_minimum_required( VERSION 2.6 )
+cmake_minimum_required( VERSION 3.5 )
 project( automotive-dlt-example4 )
 
 #


### PR DESCRIPTION
Fix:

| CMake Error at CMakeLists.txt:17 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
|
|
| -- Configuring incomplete, errors occurred!