### PR TITLE
chore: fix braces when trace load feature is enabled

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -5064,8 +5064,7 @@ DltReturnValue dlt_user_log_check_user_message(void)
                             free(messages);
                         }
                         /* continue outer flow, rwlock already unlocked */
-                        }
-                   }
+                    }
 
                     /* keep not read data in buffer */
                     if (dlt_receiver_remove(receiver, trace_load_settings_user_message_bytes_required)


### PR DESCRIPTION
Remove an unnecessary which prevented the user library from building when the trace load feature is enabled. 

## Reproduce 
build with 
``` 
    cmake \
    -DWITH_DLT_TRACE_LOAD_CTRL=ON 
```


Alexander Mohr [alexander.m.mohr@mercedes-benz.com](mailto:alexander.m.mohr@mercedes-benz.com), Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)