### PR TITLE
Fix some build failures due to wrong code in gzip handling:

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -24,7 +24,6 @@
 #include <ctype.h>
 #include <syslog.h>
 #include <sys/stat.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #include <dirent.h>
 #include <time.h>

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -1138,7 +1138,7 @@ int dlt_logstorage_prepare_on_msg(DltLogStorageFilterConfig *config,
                     } else
 #endif
                     {
-                        if (fsync(fileno(config->log)) != 0) {
+                        if (fsync(config->fd) != 0) {
                             if (errno != ENOSYS) {
                                 dlt_vlog(LOG_ERR, "%s: failed to sync log file\n", __func__);
                             }


### PR DESCRIPTION
/dlt-daemon/src/offlinelogstorage/dlt_offline_logstorage_behavior.c:1112:48: error: passing argument 1 of 'fileno' from incompatible pointer type [-Wincompatible-pointer-types]
 1112 |                         if (fsync(fileno(config->gzlog)) != 0) {
      |                                          ~~~~~~^~~~~~~
      |                                                |
      |                                                gzFile {aka struct gzFile_s *}

/dlt-daemon/src/offlinelogstorage/dlt_offline_logstorage.c: In function 'dlt_logstorage_filter_config_free': /dlt-daemon/src/offlinelogstorage/dlt_offline_logstorage.c:88:21: error: passing argument 1 of 'gzclose' from incompatible pointer type [-Wincompatible-pointer-types]
   88 |         gzclose(data->gzlog);
      |                 ~~~~^~~~~~~
      |                     |
      |                     struct gzFile_s **
In file included from /dlt-daemon/src/offlinelogstorage/dlt_offline_logstorage.h:57,
                 from /dlt-daemon/src/offlinelogstorage/dlt_offline_logstorage.c:32:
/usr/include/zlib.h:1634:39: note: expected 'gzFile' {aka 'struct gzFile_s *'} but argument is of type 'struct gzFile_s **'
 1634 | ZEXTERN int ZEXPORT    gzclose(gzFile file);
      |                                ~~~~~~~^~~~
/usr/include/zlib.h:1305:26: note: 'gzFile' declared here
 1305 | typedef struct gzFile_s *gzFile;    /* semi-opaque gzip file descriptor */
      |                          ^~~~~~