### PR TITLE
[BUG] Fix stack overflow

### DIFF
--- a/src/console/dlt-convert.c
+++ b/src/console/dlt-convert.c
@@ -432,6 +432,7 @@ int main(int argc, char *argv[])
                     close(ohandle);
                     ohandle = -1;
                 }
+                dlt_file_free(&file, vflag);
                 return -1;
             }
 
@@ -441,6 +442,8 @@ int main(int argc, char *argv[])
                     close(ohandle);
                     ohandle = -1;
                 }
+                dlt_file_free(&file, vflag);
+                return -1;
             }
 
             for (num = begin; num <= end; num++) {


### PR DESCRIPTION
Fix dlt-convert normal ascii mode missing
dlt-file-free() call before returning.

Full report and demo can be checked in Issue 793.
Reported by Shangzhi-Xu.