### PR TITLE
Fix stack overflow in dlt-covert

### DIFF
--- a/src/console/dlt-convert.c
+++ b/src/console/dlt-convert.c
@@ -74,128 +74,125 @@
  * aw          13.01.2010   initial
  */
 
- #include <dirent.h>
- #include <getopt.h>
- #include <stdio.h>
- #include <stdlib.h>
- #include <unistd.h>
- #include <string.h>
- #include <ctype.h>
- #include <errno.h>
- 
- #include <sys/stat.h>
- #include <fcntl.h>
- 
- #include <sys/uio.h> /* writev() */
- 
- #include "dlt_common.h"
- 
- #define COMMAND_SIZE        1024    /* Size of command */
- #define FILENAME_SIZE       1024    /* Size of filename */
- #define DLT_EXTENSION       "dlt"
- #define DLT_CONVERT_WS      "/tmp/dlt_convert_workspace/"
- 
- /**
-  * Print usage information of tool.
-  */
- void usage(void)
- {
-     char version[DLT_CONVERT_TEXTBUFSIZE];
- 
-     dlt_get_version(version, 255);
- 
-     printf("Usage: dlt-convert [options] [commands] file1 [file2]\n");
-     printf("Read DLT files, print DLT messages as ASCII and store the messages again.\n");
-     printf("Use filters to filter DLT messages.\n");
-     printf("Use Ranges and Output file to cut DLT files.\n");
-     printf("Use two files and Output file to join DLT files.\n");
-     printf("%s \n", version);
-     printf("Commands:\n");
-     printf("  -h            Usage\n");
-     printf("  -a            Print DLT file; payload as ASCII\n");
-     printf("  -x            Print DLT file; payload as hex\n");
-     printf("  -m            Print DLT file; payload as hex and ASCII\n");
-     printf("  -s            Print DLT file; only headers\n");
-     printf("  -o filename   Output messages in new DLT file\n");
-     printf("Options:\n");
-     printf("  -v            Verbose mode\n");
-     printf("  -c            Count number of messages\n");
-     printf("  -f filename   Enable filtering of messages\n");
-     printf("  -b number     First <number> messages to be handled\n");
-     printf("  -e number     Last <number> messages to be handled\n");
-     printf("  -w            Follow dlt file while file is increasing\n");
-     printf("  -t            Handling input compressed files (tar.gz)\n");
- }
- 
- void empty_dir(const char *dir)
- {
-     struct dirent **files = { 0 };
-     struct stat st;
-     char tmp_filename[FILENAME_SIZE] = { 0 };
- 
-     if (dir == NULL) {
-         fprintf(stderr, "ERROR: %s: invalid arguments\n", __func__);
-         return;
-     }
- 
-     if (stat(dir, &st) == 0) {
-         if (S_ISDIR(st.st_mode)) {
-             int n = scandir(dir, &files, NULL, alphasort);
-             if (n < 0) {
-                 fprintf(stderr, "ERROR: Failed to scan %s with error %s\n", dir, strerror(errno));
-                 if (files) {
-                     free(files);
-                 }
-                 return;
-             }
-             /* Do not include /. and /.. */
-             if (n < 2) {
-                 fprintf(stderr, "ERROR: Failed to scan %s with error %s\n",
-                         dir, strerror(errno));
-                 if (files) {
-                     for (int i = 0; i < n; i++)
-                         if (files[i])
-                             free(files[i]);
-                     free(files);
-                 }
-                 return;
-             }
-             else if (n == 2)
-                 printf("%s is already empty\n", dir);
-             else {
-                 for (int i = 2; i < n; i++) {
-                     memset(tmp_filename, 0, FILENAME_SIZE);
-                     /* Validate filename to prevent path traversal */
-                     if (strstr(files[i]->d_name, "/") == NULL && strstr(files[i]->d_name, "..") == NULL) {
-                         snprintf(tmp_filename, FILENAME_SIZE, "%s%s", dir, files[i]->d_name);
-                         if (remove(tmp_filename) != 0)
-                             fprintf(stderr, "ERROR: Failed to delete %s with error %s\n",
-                                     tmp_filename, strerror(errno));
-                     } else {
-                         fprintf(stderr, "WARNING: Skipping suspicious filename: %s\n", files[i]->d_name);
-                     }
-                 }
-             }
-             if (files) {
-                 for (int i = 0; i < n ; i++)
-                     if (files[i]) {
-                         free(files[i]);
-                         files[i] = NULL;
-                     }
-                 free(files);
-                 files = NULL;
-             }
-         }
-         else
-             fprintf(stderr, "ERROR: %s is not a directory\n", dir);
-     }
-     else
-         fprintf(stderr, "ERROR: Failed to stat %s with error %s\n", dir, strerror(errno));
- }
- 
- /**
-  * Main function of tool.
-  */
+#include <dirent.h>
+#include <getopt.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <sys/uio.h> /* writev() */
+
+#include "dlt_common.h"
+
+#define COMMAND_SIZE        1024    /* Size of command */
+#define FILENAME_SIZE       1024    /* Size of filename */
+#define DLT_EXTENSION       "dlt"
+#define DLT_CONVERT_WS      "/tmp/dlt_convert_workspace/"
+
+/**
+ * Print usage information of tool.
+ */
+void usage(void)
+{
+    char version[DLT_CONVERT_TEXTBUFSIZE];
+
+    dlt_get_version(version, 255);
+
+    printf("Usage: dlt-convert [options] [commands] file1 [file2]\n");
+    printf("Read DLT files, print DLT messages as ASCII and store the messages again.\n");
+    printf("Use filters to filter DLT messages.\n");
+    printf("Use Ranges and Output file to cut DLT files.\n");
+    printf("Use two files and Output file to join DLT files.\n");
+    printf("%s \n", version);
+    printf("Commands:\n");
+    printf("  -h            Usage\n");
+    printf("  -a            Print DLT file; payload as ASCII\n");
+    printf("  -x            Print DLT file; payload as hex\n");
+    printf("  -m            Print DLT file; payload as hex and ASCII\n");
+    printf("  -s            Print DLT file; only headers\n");
+    printf("  -o filename   Output messages in new DLT file\n");
+    printf("Options:\n");
+    printf("  -v            Verbose mode\n");
+    printf("  -c            Count number of messages\n");
+    printf("  -f filename   Enable filtering of messages\n");
+    printf("  -b number     First <number> messages to be handled\n");
+    printf("  -e number     Last <number> messages to be handled\n");
+    printf("  -w            Follow dlt file while file is increasing\n");
+    printf("  -t            Handling input compressed files (tar.gz)\n");
+}
+
+void empty_dir(const char *dir)
+{
+    struct dirent **files = { 0 };
+    struct stat st;
+    char tmp_filename[FILENAME_SIZE] = { 0 };
+
+    if (dir == NULL) {
+        fprintf(stderr, "ERROR: %s: invalid arguments\n", __func__);
+        return;
+    }
+
+    if (stat(dir, &st) == 0) {
+        if (S_ISDIR(st.st_mode)) {
+            int n = scandir(dir, &files, NULL, alphasort);
+            if (n < 0) {
+                fprintf(stderr, "ERROR: Failed to scan %s with error %s\n", dir, strerror(errno));
+                if (files) {
+                    free(files);
+                }
+                return;
+            }
+            /* Do not include /. and /.. */
+            if (n < 2) {
+                fprintf(stderr, "ERROR: Failed to scan %s with error %s\n",
+                        dir, strerror(errno));
+                if (files) {
+                    for (int i = 0; i < n; i++)
+                        if (files[i])
+                            free(files[i]);
+                    free(files);
+                }
+                return;
+            }
+            else if (n == 2)
+                printf("%s is already empty\n", dir);
+            else {
+                for (int i = 2; i < n; i++) {
+                    memset(tmp_filename, 0, FILENAME_SIZE);
+                    /* Validate filename to prevent path traversal */
+                    if (strstr(files[i]->d_name, "/") == NULL && strstr(files[i]->d_name, "..") == NULL) {
+                        snprintf(tmp_filename, FILENAME_SIZE, "%s%s", dir, files[i]->d_name);
+                        if (remove(tmp_filename) != 0)
+                            fprintf(stderr, "ERROR: Failed to delete %s with error %s\n",
+                                    tmp_filename, strerror(errno));
+                    } else {
+                        fprintf(stderr, "WARNING: Skipping suspicious filename: %s\n", files[i]->d_name);
+                    }
+                }
+            }
+            if (files) {
+                for (int i = 0; i < n ; i++)
+                    if (files[i]) {
+                        free(files[i]);
+                        files[i] = NULL;
+                    }
+                free(files);
+                files = NULL;
+            }
+        }
+        else
+            fprintf(stderr, "ERROR: %s is not a directory\n", dir);
+    }
+    else
+        fprintf(stderr, "ERROR: Failed to stat %s with error %s\n", dir, strerror(errno));
+}
+
 /**
  * Main function of tool.
  */


### PR DESCRIPTION
Hi team,

Regarding https://github.com/COVESA/dlt-daemon/issues/793
I designed a new buffer to avoid the usage of origin argc and argv

More details in the second commit
[Fix stack overflow in dlt-covert](https://github.com/COVESA/dlt-daemon/pull/800/commits/655113414b897a25d7f8e15ec125c1a303f8f1a4)

it works on my machine to prevent the overflow

Before fix:
```cpp
root@server:/home/shangzhi/fuz/fix/dlt-daemon/build-asan# ./poc.sh
[*] Flooding directory with 5000 files...
AddressSanitizer:DEADLYSIGNAL
=================================================================
==519997==ERROR: AddressSanitizer: stack-overflow on address 0x7ffda4b00000 (pc 0x556e521f9720 bp 0x7ffda4afeae0 sp 0x7ffda4afb820 T0)
    #0 0x556e521f9720 in main /home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-convert.c:409
    #1 0x7fe9c8e29d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #2 0x7fe9c8e29e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #3 0x556e521f7704 in _start (/home/shangzhi/fuz/fix/dlt-daemon/build-asan/src/console/dlt-convert+0x3704)

SUMMARY: AddressSanitizer: stack-overflow /home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-convert.c:409 in main
==519997==ABORTING
```

After fix
```cpp
root@server:/home/shangzhi/fuz/fix/dlt-daemon/build-asan# ./poc.sh
[*] Flooding directory with 5000 files...
```