### PR TITLE
Add JSON type validation for parsed JSON

### DIFF
--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -728,7 +728,10 @@ DltReturnValue dlt_json_filter_load(DltFilter *filter, const char *filename, int
     }
 
     j_parsed_json = json_tokener_parse_verbose(buffer, &jerr);
-
+    if (json_object_get_type(j_parsed_json) != json_type_object) {
+        pr_error("Invalid JSON type, expected object\n");
+        return DLT_RETURN_ERROR;
+    }
     if (jerr != json_tokener_success) {
         pr_error("Faild to parse given filter %s: %s\n", filename, json_tokener_error_desc(jerr));
         return DLT_RETURN_ERROR;


### PR DESCRIPTION
Hi team,

I found another null pointer dereference issue related to extended JSON filtering.

An unexpected JSON structure can lead to a crash in the library macro
`json_object_object_foreach(j_parsed_json, key, val)` inside
`dlt-control-common.c`. In this case, the parsed JSON object may be NULL,
but the code iterates over it without validation. I added a defensive
check to prevent the crash.

### PoC

```cpp
cmake .. \
  -DCMAKE_BUILD_TYPE=Debug \
  -DWITH_DLT_DEBUGGERS=ON \
  -DWITH_EXTENDED_FILTERING=ON
python3 -c 'print("\"" + "A" * 4807 + "\"", end="")' > crash.json
./src/console/dlt-receive -j crash.json localhost
```
The repetition count `4807` works on my machine but may vary across
different environments.
### Crash
```cpp
root@server:/home/shangzhi/fuz/fix/dlt-daemon/build_extend# ./src/console/dlt-receive -j crash.json localhost
The following filter(s) are applied:
AddressSanitizer:DEADLYSIGNAL
=================================================================
==643150==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000008 (pc 0x5564dd40d103 bp 0x7ffe2459b050 sp 0x7ffe24599630 T0)
==643150==The signal is caused by a READ memory access.
==643150==Hint: address points to the zero page.
    #0 0x5564dd40d103 in dlt_json_filter_load /home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-control-common.c:741
    #1 0x5564dd408c3e in main /home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-receive.c:594
    #2 0x7fb4a4429d8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #3 0x7fb4a4429e3f in __libc_start_main_impl ../csu/libc-start.c:392
    #4 0x5564dd405f04 in _start (/home/shangzhi/fuz/fix/dlt-daemon/build_extend/src/console/dlt-receive+0x5f04)
```