### PR TITLE
Fix buffer size issue in filter name generation

### DIFF
--- a/src/console/dlt-control-common.c
+++ b/src/console/dlt-control-common.c
@@ -897,8 +897,8 @@ DltReturnValue dlt_json_filter_save(DltFilter *filter, const char *filename, int
 
     for (int num = 0; num < filter->counter; num++) {
         struct json_object *tmp_json_obj = json_object_new_object();
-        char filter_name[JSON_FILTER_NAME_SIZE];
-        sprintf(filter_name, "filter%i", num);
+        char filter_name[JSON_FILTER_NAME_SIZE + 1];
+        snprintf(filter_name, sizeof(filter_name), "filter%i", num);
 
         if (filter->apid[num][DLT_ID_SIZE - 1] != 0)
             json_object_object_add(tmp_json_obj, "AppId", json_object_new_string_len(filter->apid[num], DLT_ID_SIZE));
@@ -919,7 +919,7 @@ DltReturnValue dlt_json_filter_save(DltFilter *filter, const char *filename, int
     }
 
     printf("Saving current filter into '%s'\n", filename);
-    json_object_to_file((char*)filename, json_filter_obj);
+    json_object_to_file(filename, json_filter_obj);
 
     return DLT_RETURN_OK;
 }
@@ -941,8 +941,8 @@ DltReturnValue dlt_json_filter_save(DltFilter *filter, const char *filename, int
     json_encoder_start_object(j_encoder, NULL);
 
     for (int num = 0; num < filter->counter; num++) {
-        char filter_name[JSON_FILTER_NAME_SIZE];
-        sprintf(filter_name, "filter%i", num);
+        char filter_name[JSON_FILTER_NAME_SIZE + 1];
+        snprintf(filter_name, sizeof(filter_name), "filter%i", num);
         json_encoder_start_object(j_encoder, filter_name);
 
         strncpy(s_app_id, filter->apid[num], DLT_ID_SIZE);


### PR DESCRIPTION
The compiler complain frequently when I compile with `EXTENDED_FILTERING`
```cpp
 cmake .. \
  -DCMAKE_BUILD_TYPE=Debug \
  -DWITH_DLT_DEBUGGERS=ON \
  -DWITH_EXTENDED_FILTERING=ON
```

The warnings are
```cpp
/home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-control-common.c: In function ‘dlt_json_filter_save’:
/home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-control-common.c:922:25: error: cast discards ‘const’ qualifier from pointer target type [-Werror=cast-qual]
  922 |     json_object_to_file((char*)filename, json_filter_obj);
      |                         ^
/home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-control-common.c:901:39: error: ‘sprintf’ may write a terminating nul past the end of the destination [-Werror=format-overflow=]
  901 |         sprintf(filter_name, "filter%i", num);
      |                                       ^
/home/shangzhi/fuz/fix/dlt-daemon/src/console/dlt-control-common.c:901:9: note: ‘sprintf’ output between 8 and 17 bytes into a destination of size 16
  901 |         sprintf(filter_name, "filter%i", num);
```

I fixed with `snprintf` and removed the casting