### PR TITLE
dlt: fix format and sign-conversion errors with GCC 13.3.0

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -445,7 +445,7 @@ int option_file_parser(DltDaemonLocal *daemon_local)
 #endif
 
     if (n < 0 || (size_t)n > sizeof(daemon_local->flags.loggingFilename)) {
-        dlt_vlog(LOG_WARNING, "%s: snprintf truncation/error(%ld) %s\n",
+        dlt_vlog(LOG_WARNING, "%s: snprintf truncation/error(%zd) %s\n",
                 __func__, n, daemon_local->flags.loggingFilename);
     }
     daemon_local->flags.enableLoggingFileLimit = false;
@@ -2473,7 +2473,7 @@ void dlt_daemon_exit_trigger()
     ssize_t n;
     n = snprintf(tmp, DLT_PATH_MAX, "%s/dlt", dltFifoBaseDir);
     if (n < 0 || (size_t)n > DLT_PATH_MAX) {
-        dlt_vlog(LOG_WARNING, "%s: snprintf truncation/error(%ld) %s\n",
+        dlt_vlog(LOG_WARNING, "%s: snprintf truncation/error(%zd) %s\n",
                 __func__, n, tmp);
     }
 
@@ -2676,8 +2676,8 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
     dlt_daemon_client_send(DLT_DAEMON_SEND_TO_ALL, daemon,daemon_local,
                            msg.headerbuffer, sizeof(DltStorageHeader),
                            msg.headerbuffer + sizeof(DltStorageHeader),
-                           (size_t)(msg.headersize - (int32_t)sizeof(DltStorageHeader)),
-                           msg.databuffer, (size_t)msg.datasize, verbose);
+                           (int32_t)(msg.headersize - (int32_t)sizeof(DltStorageHeader)),
+                           msg.databuffer, msg.datasize, verbose);
 
     free(msg.databuffer);
 

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -397,8 +397,8 @@ int dlt_daemon_client_send_message_to_all_client(DltDaemon *daemon,
     return dlt_daemon_client_send(DLT_DAEMON_SEND_TO_ALL, daemon, daemon_local,
                 daemon_local->msg.headerbuffer, sizeof(DltStorageHeader),
                 daemon_local->msg.headerbuffer + sizeof(DltStorageHeader),
-                (size_t)(daemon_local->msg.headersize - (int32_t)sizeof(DltStorageHeader)),
-                daemon_local->msg.databuffer, (size_t)daemon_local->msg.datasize, verbose);
+                (int32_t)(daemon_local->msg.headersize - (int32_t)sizeof(DltStorageHeader)),
+                daemon_local->msg.databuffer, daemon_local->msg.datasize, verbose);
 
 }
 
@@ -477,8 +477,8 @@ int dlt_daemon_client_send_control_message(int sock,
     if ((ret =
              dlt_daemon_client_send(sock, daemon, daemon_local, msg->headerbuffer, sizeof(DltStorageHeader),
                                     msg->headerbuffer + sizeof(DltStorageHeader),
-                                    (size_t)(msg->headersize - (int32_t)sizeof(DltStorageHeader)),
-                                    msg->databuffer, (size_t)msg->datasize, verbose))) {
+                                    (int32_t)(msg->headersize - (int32_t)sizeof(DltStorageHeader)),
+                                    msg->databuffer, msg->datasize, verbose))) {
         dlt_log(LOG_DEBUG, "dlt_daemon_control_send_control_message: DLT message send to all failed!.\n");
         return ret;
     }
@@ -1056,7 +1056,7 @@ void dlt_daemon_control_get_log_info(int sock,
 
     /* Allocate buffer for response message */
     resp.databuffer = (uint8_t *)malloc((size_t)resp.datasize);
-    resp.databuffersize = (size_t)resp.datasize;
+    resp.databuffersize = resp.datasize;
 
     if (resp.databuffer == 0) {
         dlt_daemon_control_service_response(sock,
@@ -1269,7 +1269,7 @@ int dlt_daemon_control_message_buffer_overflow(int sock,
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)
@@ -1322,7 +1322,7 @@ void dlt_daemon_control_service_response(int sock,
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)
@@ -1369,7 +1369,7 @@ int dlt_daemon_control_message_unregister_context(int sock,
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)
@@ -1423,7 +1423,7 @@ int dlt_daemon_control_message_connection_info(int sock,
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)
@@ -1471,7 +1471,7 @@ int dlt_daemon_control_message_timezone(int sock, DltDaemon *daemon, DltDaemonLo
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)
@@ -1533,7 +1533,7 @@ int dlt_daemon_control_message_marker(int sock, DltDaemon *daemon, DltDaemonLoca
 
     if (msg.databuffer == 0) {
         msg.databuffer = (uint8_t *)malloc((size_t)msg.datasize);
-        msg.databuffersize = (size_t)msg.datasize;
+        msg.databuffersize = msg.datasize;
     }
 
     if (msg.databuffer == 0)

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -1764,7 +1764,7 @@ int dlt_daemon_user_send_log_state(DltDaemon *daemon, DltDaemonApplication *app,
     if (dlt_user_set_userheader(&userheader, DLT_USER_MESSAGE_LOG_STATE) < DLT_RETURN_OK)
         return -1;
 
-    logstate.log_state = daemon->connectionState;
+    logstate.log_state = (int8_t)daemon->connectionState;
 
     /* log to FIFO */
     ret = dlt_user_log_out2_with_timeout(app->user_handle,

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -713,7 +713,7 @@ DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, size_t text
 
     if ((flags & DLT_HEADER_SHOW_TIME) == DLT_HEADER_SHOW_TIME) {
         /* print received time */
-        time_t tt = msg->storageheader->seconds;
+        time_t tt = (time_t)msg->storageheader->seconds;
         tzset();
         localtime_r(&tt, &timeinfo);
         strftime (buffer, sizeof(buffer), "%Y/%m/%d %H:%M:%S", &timeinfo);


### PR DESCRIPTION
Fix build failures when compiling dlt-daemon with GCC 13.3.0 using -Werror=format= and -Werror=sign-conversion.

The changes add explicit casts and adjust format specifiers to match the actual argument types.

No functional behavior is changed.