### PR TITLE
[FIX][REFACTOR] DLTv2 protocol byte-order and memory leaks

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2442,6 +2442,7 @@ void dlt_daemon_local_cleanup(DltDaemon *daemon, DltDaemonLocal *daemon_local, i
     dlt_event_handler_cleanup_connections(&daemon_local->pEvent);
 
     dlt_message_free(&(daemon_local->msg), daemon_local->flags.vflag);
+    dlt_message_free_v2(&(daemon_local->msgv2), daemon_local->flags.vflag);
 
     /* free shared memory */
     if (daemon_local->flags.offlineTraceDirectory[0])
@@ -2709,7 +2710,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
             msg.headerextrav2.seconds[2]=(uint8_t)((t >> 16) & 0xFF);
             msg.headerextrav2.seconds[3]=(uint8_t)((t >> 8) & 0xFF);
             msg.headerextrav2.seconds[4]= (uint8_t)(t & 0xFF);
-            msg.headerextrav2.nanoseconds |= 0x8000;
+            msg.headerextrav2.nanoseconds |= 0x80000000;
         }
 #else
         struct timespec ts;
@@ -2731,7 +2732,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
             if (ts.tv_nsec < 0x3B9ACA00) {
                 msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
             }
-            msg.headerextrav2.nanoseconds |= 0x8000;
+            msg.headerextrav2.nanoseconds |= 0x80000000;
         }
 #endif
 
@@ -2801,7 +2802,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
         msg.datasize += uiSize;
 
         /* Calc length */
-        msg.baseheaderv2->len = (uint16_t)(msg.headersizev2 - (int32_t)msg.storageheadersizev2 + msg.datasize);
+        msg.baseheaderv2->len = DLT_HTOBE_16((uint16_t)(msg.headersizev2 - (int32_t)msg.storageheadersizev2 + msg.datasize));
 
         dlt_daemon_client_send_v2(DLT_DAEMON_SEND_TO_ALL, daemon,daemon_local,
                             msg.headerbufferv2, (int)msg.storageheadersizev2,
@@ -4239,6 +4240,7 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
         if ((daemon == NULL) || (daemon_local == NULL) || (rec == NULL)) {
             dlt_vlog(LOG_ERR, "Invalid function parameters used for %s\n",
                     __func__);
+            free(buffer);
             return -1;
         }
 
@@ -4252,10 +4254,11 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
                                           (unsigned int)len,
                                           DLT_RCV_SKIP_HEADER);
 
-        if (temp < 0)
+        if (temp < 0) {
             /* Not enough bytes received */
+            free(buffer);
             return -1;
-        else {
+        } else {
             to_remove = (uint32_t) temp;
         }
 
@@ -4265,6 +4268,7 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
         usercontext.apid = (char *)malloc((size_t)usercontext.apidlen + 1);
         if (usercontext.apid == NULL) {
             dlt_log(LOG_ERR, "Memory allocation failed for usercontext.apid\n");
+            free(buffer);
             return -1;
         }
         memcpy(usercontext.apid, (buffer + offset), usercontext.apidlen);
@@ -4275,6 +4279,8 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
         usercontext.ctid = (char *)malloc((size_t)usercontext.ctidlen + 1);
         if (usercontext.ctid == NULL) {
             dlt_log(LOG_ERR, "Memory allocation failed for usercontext.ctid\n");
+            free(usercontext.apid);
+            free(buffer);
             return -1;
         }
         memcpy(usercontext.ctid, (buffer + offset), usercontext.ctidlen);
@@ -4319,6 +4325,9 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
         /* We can now remove data. */
         if (dlt_receiver_remove(rec, (int) to_remove) != DLT_RETURN_OK) {
             dlt_log(LOG_WARNING, "Can't remove bytes from receiver\n");
+            free(usercontext.apid);
+            free(usercontext.ctid);
+            free(buffer);
             return -1;
         }
 
@@ -4337,6 +4346,9 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
                     usercontext.ctid,
                     __func__);
 
+            free(usercontext.apid);
+            free(usercontext.ctid);
+            free(buffer);
             return 0;
         }
 
@@ -4347,6 +4359,9 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
             /* Plausibility check */
             if ((usercontext.log_level < DLT_LOG_DEFAULT) ||
                     (usercontext.log_level > DLT_LOG_VERBOSE)) {
+                free(usercontext.apid);
+                free(usercontext.ctid);
+                free(buffer);
                 return -1;
             }
         }
@@ -4358,6 +4373,9 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
             /* Plausibility check */
             if ((usercontext.trace_status < DLT_TRACE_STATUS_DEFAULT) ||
                     (usercontext.trace_status > DLT_TRACE_STATUS_ON)) {
+                free(usercontext.apid);
+                free(usercontext.ctid);
+                free(buffer);
                 return -1;
             }
         }
@@ -4379,6 +4397,9 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
             dlt_vlog(LOG_WARNING,
                     "Can't add ContextID '%s' for ApID '%s'\n in %s",
                     usercontext.ctid, usercontext.apid, __func__);
+            free(usercontext.apid);
+            free(usercontext.ctid);
+            free(buffer);
             return -1;
         }
         else {
@@ -4483,10 +4504,16 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
                             __func__,
                             context->apid,
                             context->ctid);
+                    free(usercontext.apid);
+                    free(usercontext.ctid);
+                    free(buffer);
                     return -1;
                 }
             }
         }
+        free(usercontext.apid);
+        free(usercontext.ctid);
+        free(buffer);
     } else if (daemon->daemon_version == DLTProtocolV1) {
         DltMessage msg;
         DltServiceGetLogInfoRequest *req = NULL;

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -594,7 +594,7 @@ int dlt_daemon_client_send_message_to_all_client_v2(DltDaemon *daemon,
 
     /* Save old storage header size before we recalculate it */
     uint32_t old_storage_size = daemon_local->msgv2.storageheadersizev2;
-    
+
     /* prepare storage header */
     if (DLT_IS_HTYP2_WEID(daemon_local->msgv2.baseheaderv2->htyp2)) {
         ecu_ptr = daemon_local->msgv2.extendedheaderv2.ecid;
@@ -633,14 +633,14 @@ int dlt_daemon_client_send_message_to_all_client_v2(DltDaemon *daemon,
     memcpy(new_headerbufferv2 + daemon_local->msgv2.storageheadersizev2,
            temp_buffer + old_storage_size,
            (daemon_local->msgv2.baseheadersizev2 + daemon_local->msgv2.baseheaderextrasizev2));
-    
+
     /* Copy extended header from temp buffer */
     uint32_t old_extended_offset = old_storage_size + daemon_local->msgv2.baseheadersizev2 + daemon_local->msgv2.baseheaderextrasizev2;
     uint32_t new_extended_offset = daemon_local->msgv2.storageheadersizev2 + daemon_local->msgv2.baseheadersizev2 + daemon_local->msgv2.baseheaderextrasizev2;
     memcpy(new_headerbufferv2 + new_extended_offset,
            temp_buffer + old_extended_offset,
            temp_extended_size);
-    
+
     free(temp_buffer);
 
     /* free the original header buffer and install the new one */
@@ -871,7 +871,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
         msg->headerextrav2.seconds[2]=(t >> 16) & 0xFF;
         msg->headerextrav2.seconds[3]=(t >> 8) & 0xFF;
         msg->headerextrav2.seconds[4]= t & 0xFF;
-        msg->headerextrav2.nanoseconds |= 0x8000;
+        msg->headerextrav2.nanoseconds |= 0x80000000;
     }
 #else
     struct timespec ts;
@@ -893,7 +893,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
         if (ts.tv_nsec < 0x3B9ACA00) {
             msg->headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
         }
-        msg->headerextrav2.nanoseconds |= 0x8000;
+        msg->headerextrav2.nanoseconds |= 0x80000000;
     }
 #endif
 
@@ -955,7 +955,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
         return DLT_RETURN_ERROR;
     }
 
-    msg->baseheaderv2->len = (uint16_t)len;
+    msg->baseheaderv2->len = DLT_HTOBE_16((uint16_t)len);
 
     if ((ret =
              dlt_daemon_client_send_v2(sock, daemon, daemon_local, msg->headerbufferv2, (int)msg->storageheadersizev2,
@@ -2104,7 +2104,7 @@ void dlt_daemon_control_get_log_info_v2(int sock,
     DltServiceGetLogInfoRequestV2 *req;
     DltMessageV2 resp;
     DltDaemonContext *context = NULL;
-    DltDaemonApplication *application = (DltDaemonApplication *)malloc(sizeof(DltDaemonApplication));
+    DltDaemonApplication *application = NULL;
 
     int num_applications = 0, num_contexts = 0;
     uint16_t count_app_ids = 0, count_con_ids = 0;

--- a/src/daemon/dlt_daemon_common.c
+++ b/src/daemon/dlt_daemon_common.c
@@ -1847,7 +1847,7 @@ DltDaemonContext *dlt_daemon_context_add_v2(DltDaemon *daemon,
     DltDaemonContext *old;
     int new_context = 0;
     DltDaemonRegisteredUsers *user_list = NULL;
-    DltDaemonApplication *application = (DltDaemonApplication *)malloc(sizeof(DltDaemonApplication));
+    DltDaemonApplication *application = NULL;
 
     PRINT_FUNCTION_VERBOSE(verbose);
 
@@ -2322,11 +2322,20 @@ int dlt_daemon_contexts_clear(DltDaemon *daemon, char *ecu, int verbose)
     if (users == NULL)
         return DLT_RETURN_ERROR;
 
-    for (i = 0; i < users->num_contexts; i++)
+    for (i = 0; i < users->num_contexts; i++) {
         if (users->contexts[i].context_description != NULL) {
             free(users->contexts[i].context_description);
             users->contexts[i].context_description = NULL;
         }
+        if (users->contexts[i].apid2 != NULL) {
+            free(users->contexts[i].apid2);
+            users->contexts[i].apid2 = NULL;
+        }
+        if (users->contexts[i].ctid2 != NULL) {
+            free(users->contexts[i].ctid2);
+            users->contexts[i].ctid2 = NULL;
+        }
+    }
 
     if (users->contexts) {
         free(users->contexts);
@@ -2711,7 +2720,7 @@ int dlt_daemon_user_send_log_level_v2(DltDaemon *daemon, DltDaemonContext *conte
     DltUserHeader userheader;
     DltUserControlMsgLogLevel usercontext;
     DltReturnValue ret;
-    DltDaemonApplication *app = (DltDaemonApplication *)malloc(sizeof(DltDaemonApplication));
+    DltDaemonApplication *app = NULL;
 
     PRINT_FUNCTION_VERBOSE(verbose);
 
@@ -2763,7 +2772,6 @@ int dlt_daemon_user_send_log_level_v2(DltDaemon *daemon, DltDaemonContext *conte
             if (app != NULL)
                 dlt_daemon_application_reset_user_handle(daemon, app, verbose);
         }
-        free(app);
     }
     return (ret == DLT_RETURN_OK) ? DLT_RETURN_OK : DLT_RETURN_ERROR;
 }

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -1025,7 +1025,7 @@ DltReturnValue dlt_client_send_ctrl_msg_v2(DltClient *client, char *apid, char *
         msg.headerextrav2.seconds[2]=(t >> 16) & 0xFF;
         msg.headerextrav2.seconds[3]=(t >> 8) & 0xFF;
         msg.headerextrav2.seconds[4]= t & 0xFF;
-        msg.headerextrav2.nanoseconds |= 0x8000;
+        msg.headerextrav2.nanoseconds |= 0x80000000;
     }
     #else
     struct timespec ts;
@@ -1047,7 +1047,7 @@ DltReturnValue dlt_client_send_ctrl_msg_v2(DltClient *client, char *apid, char *
         if (ts.tv_nsec < 0x3B9ACA00) {
             msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
         }
-        msg.headerextrav2.nanoseconds |= 0x8000;
+        msg.headerextrav2.nanoseconds |= 0x80000000;
     }
     #endif
 
@@ -1108,7 +1108,7 @@ DltReturnValue dlt_client_send_ctrl_msg_v2(DltClient *client, char *apid, char *
         dlt_message_free_v2(&msg, 0);
         return DLT_RETURN_ERROR;
     }
-    msg.baseheaderv2->len = (uint16_t)len;
+    msg.baseheaderv2->len = DLT_HTOBE_16((uint16_t)len);
 
     /* Send data (without storage header) */
     if ((client->mode == DLT_CLIENT_MODE_TCP) || (client->mode == DLT_CLIENT_MODE_SERIAL)) {

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -5460,7 +5460,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
             msg.headerextrav2.seconds[2]=(t >> 16) & 0xFF;
             msg.headerextrav2.seconds[3]=(t >> 8) & 0xFF;
             msg.headerextrav2.seconds[4]= t & 0xFF;
-            msg.headerextrav2.nanoseconds |= 0x8000;
+            msg.headerextrav2.nanoseconds |= 0x80000000;
         }
     #else
         struct timespec ts;
@@ -5482,7 +5482,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
             if (ts.tv_nsec < 0x3B9ACA00) {
                 msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
             }
-            msg.headerextrav2.nanoseconds |= 0x8000;
+            msg.headerextrav2.nanoseconds |= 0x80000000;
         }
     #endif
     }
@@ -5589,7 +5589,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
     }
     len = (uint32_t)tmplen;
 
-    msg.baseheaderv2->len = (uint16_t) len;
+    msg.baseheaderv2->len = DLT_HTOBE_16((uint16_t) len);
 
     /* print to std out, if enabled */
     if ((dlt_user.local_print_mode != DLT_PM_FORCE_OFF) &&
@@ -6522,7 +6522,7 @@ DltReturnValue dlt_user_print_msg_v2(DltMessageV2 *msg, DltContextData *log)
     databuffersize_tmp = msg->databuffersize;
 
     /* Act like a receiver, convert header back to host format */
-    //msg->baseheaderv2->len = DLT_BETOH_16(msg->baseheaderv2->len);
+    msg->baseheaderv2->len = DLT_BETOH_16(msg->baseheaderv2->len);
     //dlt_message_get_storageparameters_v2(msg, 0);
     //dlt_message_get_extraparameters_v2(msg, 0);
 
@@ -6542,7 +6542,7 @@ DltReturnValue dlt_user_print_msg_v2(DltMessageV2 *msg, DltContextData *log)
     msg->databuffersize = databuffersize_tmp;
     msg->datasize = datasize_tmp;
 
-    //msg->baseheaderv2->len = DLT_HTOBE_16(msg->baseheaderv2->len);
+    msg->baseheaderv2->len = DLT_HTOBE_16(msg->baseheaderv2->len);
     return DLT_RETURN_OK;
 }
 

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1028,6 +1028,12 @@ DltReturnValue dlt_message_free_v2(DltMessageV2 *msg, int verbose)
         msg->headersizev2 = 0;
     }
 
+    /* delete tags if exists */
+    if (msg->extendedheaderv2.tag) {
+        free(msg->extendedheaderv2.tag);
+        msg->extendedheaderv2.tag = NULL;
+    }
+
     /* delete databuffer if exists */
     if (msg->databuffer) {
         free(msg->databuffer);
@@ -2010,7 +2016,7 @@ int dlt_message_read_v2(DltMessageV2 *msg, uint8_t *buffer, unsigned int length,
     int32_t temp_datasize;
 
     // Assign a temp_baseheader_len of int32_t from msg->baseheaderv2->len and use below
-    temp_datasize = msg->baseheaderv2->len - msg->headersizev2;
+    temp_datasize = DLT_BETOH_16(msg->baseheaderv2->len) - msg->headersizev2;
 
     /* check data size */
     if (temp_datasize < 0) {
@@ -2295,8 +2301,9 @@ DltReturnValue dlt_message_set_extraparameters_v2(DltMessageV2 *msg, int verbose
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2 + 1,
                &(msg->headerextrav2.noar),
                1);
+        uint32_t nanoseconds_be = DLT_HTOBE_32(msg->headerextrav2.nanoseconds);
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2 + 2,
-               &(msg->headerextrav2.nanoseconds),
+               &nanoseconds_be,
                4);
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2 + 6,
                msg->headerextrav2.seconds,
@@ -2304,14 +2311,16 @@ DltReturnValue dlt_message_set_extraparameters_v2(DltMessageV2 *msg, int verbose
     }
 
     if (msgcontent == DLT_NON_VERBOSE_DATA_MSG) {
+        uint32_t nanoseconds_be = DLT_HTOBE_32(msg->headerextrav2.nanoseconds);
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2,
-               &(msg->headerextrav2.nanoseconds),
+               &nanoseconds_be,
                4);
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2 + 4,
                msg->headerextrav2.seconds,
                5);
+        uint32_t msid_be = DLT_HTOBE_32(msg->headerextrav2.msid);
         memcpy(msg->headerbufferv2 + msg->storageheadersizev2 + msg->baseheadersizev2 + 9,
-               &(msg->headerextrav2.msid),
+               &msid_be,
                4);
     }
 
@@ -2398,8 +2407,9 @@ DltReturnValue dlt_message_set_extendedparameters_v2(DltMessageV2 *msg)
     }
 
     if (DLT_IS_HTYP2_WSID(msg->baseheaderv2->htyp2)) {
+        uint32_t seid_be = DLT_HTOBE_32(msg->extendedheaderv2.seid);
         memcpy(msg->headerbufferv2 + pntroffset,
-               &(msg->extendedheaderv2.seid),
+               &seid_be,
                4);
 
         pntroffset = pntroffset + 4;
@@ -2420,8 +2430,9 @@ DltReturnValue dlt_message_set_extendedparameters_v2(DltMessageV2 *msg)
 
         pntroffset = pntroffset + msg->extendedheaderv2.finalen + 1;
 
+        uint32_t linr_be = DLT_HTOBE_32(msg->extendedheaderv2.linr);
         memcpy(msg->headerbufferv2 + pntroffset,
-               &(msg->extendedheaderv2.linr),
+               &linr_be,
                4);
 
         pntroffset = pntroffset + 4;
@@ -2592,6 +2603,11 @@ DltReturnValue dlt_message_get_extendedparameters_from_recievedbuffer_v2(DltMess
                1);
         pntroffset = pntroffset + 1;
 
+        /* Free previously allocated tags before re-allocating */
+        if (msg->extendedheaderv2.tag != NULL) {
+            free(msg->extendedheaderv2.tag);
+            msg->extendedheaderv2.tag = NULL;
+        }
         msg->extendedheaderv2.tag = (DltTag *)malloc((msg->extendedheaderv2.notg) * sizeof(DltTag));
         if (msg->extendedheaderv2.tag == NULL) {
             return DLT_RETURN_ERROR;


### PR DESCRIPTION
Fix big-endian encoding for v2 multi-byte header fields:
- Add DLT_HTOBE_16 for baseheaderv2->len on all write paths
- Add DLT_BETOH_16 for baseheaderv2->len on receive path
- Add DLT_HTOBE_32 for nanoseconds, msid, seid, linr fields
- Fix monotonic timestamp flag from 0x8000 to 0x80000000 (bit 31)
- Uncomment byte-swap in dlt_user_print_msg_v2

Fix memory leaks detected by AddressSanitizer:
- Free tag array in dlt_message_free_v2 and before re-allocation
- Add dlt_message_free_v2 for msgv2 in dlt_daemon_local_cleanup
- Remove unnecessary malloc for DltDaemonApplication pointer
- Free buffer, apid, ctid on all exit paths in register_context
- Free apid2/ctid2 in dlt_daemon_contexts_clear

To users: You can use dlt-viewer now for dltv2 protocol with dlt-daemon -x 2.
File->Settings->Project Other-> Support dltv2 decoding