### PR TITLE
fix: prevent null deref and OOB read in DLT v2 control handlers (#825, #824)

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2105,6 +2105,12 @@ void dlt_daemon_control_get_log_info_v2(int sock,
     DltMessageV2 resp;
     DltDaemonContext *context = NULL;
     DltDaemonApplication *application = NULL;
+    /* Local buffers for variable-length apid/ctid parsed from the request.
+     * DltServiceGetLogInfoRequestV2 uses pointer fields (char *apid, char *ctid)
+     * which are NULL after calloc; dlt_set_id_v2 is a no-op on NULL.
+     * Sized DLT_V2_ID_SIZE + 1 so a null terminator is always present (issue #6). */
+    char req_apid_buf[DLT_V2_ID_SIZE + 1];
+    char req_ctid_buf[DLT_V2_ID_SIZE + 1];
 
     int num_applications = 0, num_contexts = 0;
     uint16_t count_app_ids = 0, count_con_ids = 0;
@@ -2155,7 +2161,10 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         free(req);
         return;
     }
-    dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
+    /* Issue #1: req->apid is NULL after calloc; use local buffer, then point req->apid at it. */
+    memset(req_apid_buf, 0, sizeof(req_apid_buf));
+    dlt_set_id_v2(req_apid_buf, (const char *)(msg->databuffer + db_offset), req->apidlen);
+    req->apid = req_apid_buf;
     db_offset = db_offset + (int)req->apidlen;
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
@@ -2163,7 +2172,10 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         free(req);
         return;
     }
-    dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
+    /* Issue #2: req->ctid is NULL after calloc; use local buffer, then point req->ctid at it. */
+    memset(req_ctid_buf, 0, sizeof(req_ctid_buf));
+    dlt_set_id_v2(req_ctid_buf, (const char *)(msg->databuffer + db_offset), req->ctidlen);
+    req->ctid = req_ctid_buf;
     db_offset = db_offset + (int)req->ctidlen;
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);
 
@@ -3674,12 +3686,15 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     PRINT_FUNCTION_VERBOSE(verbose);
     char *apid = NULL;
     char *ctid = NULL;
-    char apid_buf[DLT_V2_ID_SIZE] = {0};
-    char ctid_buf[DLT_V2_ID_SIZE] = {0};
+    /* Issue #6: sized DLT_V2_ID_SIZE + 1 so a null terminator is always present
+     * even when dlt_set_id_v2 fills all DLT_V2_ID_SIZE bytes. */
+    char apid_buf[DLT_V2_ID_SIZE + 1] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE + 1] = {0};
     DltServiceSetLogLevelV2 req = {0};
     DltDaemonContext *context = NULL;
-    int8_t apid_length = 0;
-    int8_t ctid_length = 0;
+    /* Issue #5: uint8_t (0-255) avoids negative indices when apidlen/ctidlen >= 128. */
+    uint8_t apid_length = 0;
+    uint8_t ctid_length = 0;
     int offset = 0;
 
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
@@ -3692,6 +3707,9 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint32_t);
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+    /* Issue #3: bounds check before reading variable-length apid bytes. */
+    if (offset + (int)req.apidlen > msg->datasize)
+        return;
     if (req.apidlen > 0) {
         dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + offset), req.apidlen);
         apid = apid_buf;
@@ -3699,6 +3717,10 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + req.apidlen;
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+    /* Issue #4: bounds check before reading variable-length ctid bytes and the
+     * remaining fixed fields (log_level: 1 byte, com: DLT_ID_SIZE bytes). */
+    if (offset + (int)req.ctidlen + (int)sizeof(uint8_t) + DLT_ID_SIZE > msg->datasize)
+        return;
     if (req.ctidlen > 0) {
         dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + offset), req.ctidlen);
         ctid = ctid_buf;
@@ -3711,8 +3733,8 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     if (daemon_local->flags.enforceContextLLAndTS)
         req.log_level = (uint8_t) getStatus(req.log_level, daemon_local->flags.contextLogLevel);
 
-    apid_length = (int8_t) req.apidlen;
-    ctid_length = (int8_t) req.ctidlen;
+    apid_length = (uint8_t) req.apidlen;
+    ctid_length = (uint8_t) req.ctidlen;
 
     if ((apid_length != 0) && (apid[apid_length - 1] == '*') && (ctid == NULL)) { /*apid provided having '*' in it and ctid is null*/
         dlt_daemon_find_multiple_context_and_send_log_level_v2(sock,
@@ -3742,7 +3764,7 @@ void dlt_daemon_control_set_log_level_v2(int sock,
                                                             daemon_local,
                                                             1,
                                                             apid,
-                                                            apid_length,
+                                                            (int8_t) apid_length,
                                                             (int8_t) req.log_level,
                                                             verbose);
     }
@@ -3753,7 +3775,7 @@ void dlt_daemon_control_set_log_level_v2(int sock,
                                                             daemon_local,
                                                             0,
                                                             ctid,
-                                                            ctid_length,
+                                                            (int8_t) ctid_length,
                                                             (int8_t) req.log_level,
                                                             verbose);
     }

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2151,10 +2151,18 @@ void dlt_daemon_control_get_log_info_v2(int sock,
     db_offset = db_offset + (int)sizeof(uint8_t);
     memcpy(&(req->apidlen), msg->databuffer + db_offset, sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+    if ((int)db_offset + (int)req->apidlen + (int)sizeof(uint8_t) > (int)msg->datasize) {
+        free(req);
+        return;
+    }
     dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
     db_offset = db_offset + (int)req->apidlen;
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+    if ((int)db_offset + (int)req->ctidlen + (int)DLT_ID_SIZE > (int)msg->datasize) {
+        free(req);
+        return;
+    }
     dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
     db_offset = db_offset + (int)req->ctidlen;
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);
@@ -3664,8 +3672,10 @@ void dlt_daemon_control_set_log_level_v2(int sock,
                                       int verbose)
 {
     PRINT_FUNCTION_VERBOSE(verbose);
-    char *apid =NULL;
-    char *ctid =NULL;
+    char *apid = NULL;
+    char *ctid = NULL;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     DltServiceSetLogLevelV2 req = {0};
     DltDaemonContext *context = NULL;
     int8_t apid_length = 0;
@@ -3682,11 +3692,17 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint32_t);
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    dlt_set_id_v2(req.apid, (const char *)(msg->databuffer + offset), req.apidlen);
+    if (req.apidlen > 0) {
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + offset), req.apidlen);
+        apid = apid_buf;
+    }
     offset = offset + req.apidlen;
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    dlt_set_id_v2(req.ctid, (const char *)(msg->databuffer + offset), req.ctidlen);
+    if (req.ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + offset), req.ctidlen);
+        ctid = ctid_buf;
+    }
     offset = offset + req.ctidlen;
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
@@ -3696,9 +3712,7 @@ void dlt_daemon_control_set_log_level_v2(int sock,
         req.log_level = (uint8_t) getStatus(req.log_level, daemon_local->flags.contextLogLevel);
 
     apid_length = (int8_t) req.apidlen;
-    dlt_set_id_v2(apid, req.apid, req.apidlen);
     ctid_length = (int8_t) req.ctidlen;
-    dlt_set_id_v2(ctid, req.ctid, req.ctidlen);
 
     if ((apid_length != 0) && (apid[apid_length - 1] == '*') && (ctid == NULL)) { /*apid provided having '*' in it and ctid is null*/
         dlt_daemon_find_multiple_context_and_send_log_level_v2(sock,


### PR DESCRIPTION
## Summary

Two bugs in the DLT v2 control message path, both reachable by a remote DLT client sending a crafted control message, causing daemon crash (DoS).

Both fixes are in `src/daemon/dlt_daemon_client.c`, one PR.

---

## Bug 1 — NULL dereference in `dlt_daemon_control_set_log_level_v2` (fixes #825)

**Root cause**: `DltServiceSetLogLevelV2.apid/ctid` are `char *` fields zero-initialised to NULL by `req = {0}`. `dlt_set_id_v2()` guards against a NULL destination and returns immediately — the apid/ctid bytes from the message were never stored. The subsequent `dlt_set_id_v2(apid, req.apid, ...)` calls at lines 3699–3701 were also no-ops (both args NULL). When `apidlen > 0`, the condition `apid[apid_length - 1]` dereferenced a NULL pointer, crashing the daemon.

UBSan: `runtime error: load of null pointer of type 'char'` at `dlt_daemon_client.c:3703`.

**Trigger**: Any SET_LOG_LEVEL v2 message with `apidlen > 0`.

**Fix**: Introduce stack buffers `apid_buf/ctid_buf[DLT_V2_ID_SIZE]`, parse apid/ctid directly from `msg->databuffer` into these buffers, and set the `apid`/`ctid` pointers conditionally (NULL preserved for "not provided"). Remove the two broken `dlt_set_id_v2(NULL, ...)` calls.

---

## Bug 2 — Heap OOB read in `dlt_daemon_control_get_log_info_v2` (fixes #824)

**Root cause**: The fixed-size check validates only 11 bytes (`DLT_SERVICE_GET_LOG_INFO_REQUEST_FIXED_SIZE_V2`). `req->apidlen` is a `uint8_t` read directly from the message (attacker-controlled, 0–255). `db_offset` was advanced by `req->apidlen` at line 2155 without checking whether it remains within `msg->datasize`. The `memcpy` at line 2156 then read past the buffer end.

ASAN: `heap-buffer-overflow READ` at `dlt_daemon_client.c:2156`.

**Trigger**: GET_LOG_INFO v2 message with `apidlen` large enough to push `db_offset` past `msg->datasize`.

**Fix**: Add bounds checks after reading `apidlen` and `ctidlen` before advancing `db_offset`. On overflow, `free(req)` and return.

---

## Diff summary

```
src/daemon/dlt_daemon_client.c | 26 ++++++++++++++++++++------
1 file changed, 20 insertions(+), 6 deletions(-)
```

---

## Safety / standards

- CWE-476: NULL Pointer Dereference (#825)
- CWE-125: Out-of-Bounds Read (#824)
- CWE-20: Improper Input Validation (both)
- AUTOSAR SWS_DLT_01000
- ISO 26262-6 §9.4.4d

---

Fixes #825
Fixes #824

Signed-off-by: Akihiko Komada <aki1770@gmail.com>