### PR TITLE
fix: prevent stack overflow and /tmp race in dlt-convert workspace (#793)

### DIFF
--- a/src/console/dlt-convert.c
+++ b/src/console/dlt-convert.c
@@ -229,6 +229,7 @@ int main(int argc, char *argv[])
     memset(&st, 0, sizeof(struct stat));
     struct dirent **files = { 0 };
     int n = 0;
+    int original_argc = argc;
 
     struct iovec iov[2];
     int bytes_written = 0;
@@ -358,12 +359,13 @@ int main(int argc, char *argv[])
                 }
                 return -1;
             }
+            /* Directory exists — clear any pre-existing contents (including
+             * attacker-planted files) before we use it as a workspace. */
+            if (stat(DLT_CONVERT_WS, &st) == 0 && S_ISDIR(st.st_mode))
+                empty_dir(DLT_CONVERT_WS);
         }
         else {
-            if (S_ISDIR(st.st_mode))
-                empty_dir(DLT_CONVERT_WS);
-            else
-                fprintf(stderr, "ERROR: %s is not a directory", DLT_CONVERT_WS);
+            empty_dir(DLT_CONVERT_WS);
         }
 
         for (index = optind; index < argc; index++) {
@@ -398,6 +400,9 @@ int main(int argc, char *argv[])
 
         /* do not include ./ and ../ in the files */
         argc = optind + (n - 2);
+        /* Guard: never exceed the original argv bounds. */
+        if (argc > original_argc)
+            argc = original_argc;
     }
 
     for (index = optind; index < argc; index++) {


### PR DESCRIPTION
## Summary

Fixes two bugs in `dlt-convert.c` reported in issue #793:

**Bug 1 — Stack overflow via inflated `argc`**

`dlt-convert` creates a workspace directory at `DLT_CONVERT_WS` (`/tmp/dlt_convert_workspace/`) and builds a dynamic `argv[]` array from its contents. The count `n` is read from the directory (attacker-controllable via `/tmp` world-write). The computed `argc = optind + (n - 2)` can exceed the original `argc`, causing `argv[index] = tmp_filename` to write past the original stack-allocated `argv` bounds — CWE-121 (stack-based buffer overflow).

Fix: record `original_argc` before workspace processing; cap the computed `argc` at `original_argc`.

**Bug 2 — `/tmp` race: `empty_dir()` never called on EEXIST path**

On `mkdir(DLT_CONVERT_WS)` returning `EEXIST`, the code calls `stat(DLT_CONVERT_WS, &st)` but `st` was zero-initialized and never populated by the preceding `mkdir`. `S_ISDIR(st.st_mode)` always evaluates false on a zeroed `st_mode`, so `empty_dir()` is never invoked — stale files accumulate and feed the inflated `argc` count. CWE-377 (insecure temporary file).

Fix: add explicit `stat()` call on the EEXIST path before checking `S_ISDIR`; remove the dead `S_ISDIR` check in the fresh-mkdir branch (newly created directory is always a directory).

## Changes

`src/console/dlt-convert.c` — 1 file, +9/-4 lines

- Add `int original_argc = argc;` before workspace processing
- EEXIST path: call `stat(DLT_CONVERT_WS, &st)` explicitly, then guard `empty_dir()` with real `S_ISDIR` result
- Fresh-mkdir path: call `empty_dir()` unconditionally (directory was just created)
- After `argc` inflation: `if (argc > original_argc) argc = original_argc;`

## Safety framing

- CWE-121 (stack-based buffer overflow)
- CWE-377 (insecure temporary file)
- CWE-20 (improper input validation)
- AUTOSAR SWS_DLT_01000, ISO 26262-6 §9.4.4d

Closes #793

Signed-off-by: Akihiko Komada <aki1770@gmail.com>