### PR TITLE
fix: cap dlt_buffer_get copy size to max_size to prevent overflow (#829)

### DIFF
--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -4242,21 +4242,29 @@ int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete
         return DLT_RETURN_ERROR; /* ERROR */
     }
 
-    /* third check size */
-    if (max_size && (head.size > max_size))
+    /* third check size — cap copy to max_size to prevent buffer overflow (CWE-119) */
+    int copy_size = head.size;
+    if (max_size && (head.size > max_size)) {
         dlt_vlog(LOG_WARNING,
-                 "%s: Buffer: Max size is smaller than read header size. Max size: %d\n",
-                 __func__, max_size);
+                 "%s: Buffer: read header size %d exceeds max_size %d, clipping copy\n",
+                 __func__, head.size, max_size);
+        copy_size = max_size;
+    }
 
     /* nothing to do but data does not fit provided buffer */
 
     if ((data != NULL) && max_size) {
-        /* read data */
-        dlt_buffer_read_block(buf, &read, data, (unsigned int)head.size);
+        /* read data — copy at most copy_size bytes to avoid overflow */
+        dlt_buffer_read_block(buf, &read, data, (unsigned int)copy_size);
 
-        if (delete)
+        if (delete) {
+            /* advance read pointer past full head.size block for ring buffer consistency */
+            int next_read = read + (head.size - copy_size);
+            if ((unsigned int)next_read >= buf->size)
+                next_read -= (int)buf->size;
             /* update buffer pointers */
-            ((int *)(buf->shm))[1] = read; /* set new read pointer */
+            ((int *)(buf->shm))[1] = next_read;
+        }
 
     }
     else if (delete)
@@ -4276,7 +4284,7 @@ int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete
             dlt_buffer_minimize_size(buf);
     }
 
-    return head.size; /* OK */
+    return copy_size; /* OK */
 }
 
 int dlt_buffer_pull(DltBuffer *buf, unsigned char *data, int max_size)

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -4244,7 +4244,7 @@ int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete
 
     /* third check size — cap copy to max_size to prevent buffer overflow (CWE-119) */
     int copy_size = head.size;
-    if (max_size && (head.size > max_size)) {
+    if ((max_size > 0) && (head.size > max_size)) {
         dlt_vlog(LOG_WARNING,
                  "%s: Buffer: read header size %d exceeds max_size %d, clipping copy\n",
                  __func__, head.size, max_size);
@@ -4253,14 +4253,14 @@ int dlt_buffer_get(DltBuffer *buf, unsigned char *data, int max_size, int delete
 
     /* nothing to do but data does not fit provided buffer */
 
-    if ((data != NULL) && max_size) {
+    if ((data != NULL) && (max_size > 0)) {
         /* read data — copy at most copy_size bytes to avoid overflow */
         dlt_buffer_read_block(buf, &read, data, (unsigned int)copy_size);
 
         if (delete) {
             /* advance read pointer past full head.size block for ring buffer consistency */
             int next_read = read + (head.size - copy_size);
-            if ((unsigned int)next_read >= buf->size)
+            if ((unsigned int)next_read > buf->size)
                 next_read -= (int)buf->size;
             /* update buffer pointers */
             ((int *)(buf->shm))[1] = next_read;

--- a/tests/gtest_dlt_common.cpp
+++ b/tests/gtest_dlt_common.cpp
@@ -848,6 +848,162 @@ TEST(t_dlt_buffer_get, nullpointer)
     EXPECT_GE(-1, dlt_buffer_get(&buf, NULL, size, 1));
     EXPECT_LE(DLT_RETURN_OK, dlt_buffer_free_dynamic(&buf));
 }
+TEST(t_dlt_buffer_get, clipped_copy_no_overflow)
+{
+    /* Reproducer for issue #829 (credit: @edgdsj): a record larger than the
+     * caller's buffer must not overflow it. dlt_buffer_get() has to clip the
+     * copy to max_size and report the clipped size. */
+    DltBuffer buf;
+    unsigned char record[300];
+    unsigned char storage[400];
+    int i;
+
+    for (i = 0; i < (int)sizeof(record); i++)
+        record[i] = (unsigned char)(i & 0xff);
+
+    /* sentinel beyond max_size must stay untouched */
+    memset(storage, 0xAA, sizeof(storage));
+
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_buffer_init_dynamic(&buf, DLT_USER_RINGBUFFER_MIN_SIZE, DLT_USER_RINGBUFFER_MAX_SIZE,
+                                      DLT_USER_RINGBUFFER_STEP_SIZE));
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record, (unsigned int)sizeof(record)));
+
+    /* destination is only 100 bytes: expect a clipped copy of 100 bytes */
+    EXPECT_EQ(100, dlt_buffer_get(&buf, storage, 100, 1));
+
+    /* first 100 bytes are the record prefix */
+    for (i = 0; i < 100; i++)
+        EXPECT_EQ(record[i], storage[i]);
+
+    /* nothing was written past max_size */
+    for (i = 100; i < (int)sizeof(storage); i++)
+        EXPECT_EQ(0xAA, storage[i]);
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_free_dynamic(&buf));
+}
+TEST(t_dlt_buffer_get, clipped_delete_preserves_next_record)
+{
+    /* After a clipped read with delete=1 the read pointer must advance by the
+     * full head.size so the next block header is found (reviewer invariant on
+     * PR #834): record B must come back intact after record A was clipped. */
+    DltBuffer buf;
+    unsigned char record_a[300];
+    unsigned char record_b[50];
+    unsigned char storage_a[100];
+    unsigned char storage_b[64];
+    int i;
+
+    for (i = 0; i < (int)sizeof(record_a); i++)
+        record_a[i] = (unsigned char)(i & 0xff);
+
+    for (i = 0; i < (int)sizeof(record_b); i++)
+        record_b[i] = (unsigned char)(0xF0 ^ (i & 0xff));
+
+    memset(storage_a, 0xAA, sizeof(storage_a));
+    memset(storage_b, 0xAA, sizeof(storage_b));
+
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_buffer_init_dynamic(&buf, DLT_USER_RINGBUFFER_MIN_SIZE, DLT_USER_RINGBUFFER_MAX_SIZE,
+                                      DLT_USER_RINGBUFFER_STEP_SIZE));
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record_a, (unsigned int)sizeof(record_a)));
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record_b, (unsigned int)sizeof(record_b)));
+
+    /* clipped delete-get of record A */
+    EXPECT_EQ((int)sizeof(storage_a), dlt_buffer_get(&buf, storage_a, (int)sizeof(storage_a), 1));
+
+    /* record B must be read back completely and intact */
+    EXPECT_EQ((int)sizeof(record_b), dlt_buffer_get(&buf, storage_b, (int)sizeof(storage_b), 1));
+
+    for (i = 0; i < (int)sizeof(record_b); i++)
+        EXPECT_EQ(record_b[i], storage_b[i]);
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_free_dynamic(&buf));
+}
+TEST(t_dlt_buffer_get, clipped_delete_exact_boundary)
+{
+    /* A clipped delete-get of a record ending exactly at buf->size must leave
+     * read == write (the buffer convention allows read == buf->size, compare
+     * dlt_buffer_read_block()); wrapping read to 0 here would make the next
+     * call spuriously report "SHM should be empty, but is not" and reset. */
+    DltBuffer buf;
+    unsigned char record_a[1024];
+    unsigned char record_b[50];
+    unsigned char storage[100];
+    int payload_size;
+    int i;
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_init_dynamic(&buf, 1024, 1024, 1024));
+
+    /* single record filling the ring buffer exactly to buf->size */
+    payload_size = (int)buf.size - (int)sizeof(DltBufferBlockHead);
+    ASSERT_GT(payload_size, 100);
+    ASSERT_LE(payload_size, (int)sizeof(record_a));
+
+    for (i = 0; i < payload_size; i++)
+        record_a[i] = (unsigned char)(i & 0xff);
+
+    memset(storage, 0xAA, sizeof(storage));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record_a, (unsigned int)payload_size));
+
+    /* clipped delete-get: block end == buf->size */
+    EXPECT_EQ((int)sizeof(storage), dlt_buffer_get(&buf, storage, (int)sizeof(storage), 1));
+
+    for (i = 0; i < (int)sizeof(storage); i++)
+        EXPECT_EQ(record_a[i], storage[i]);
+
+    /* buffer must be consistently empty: read == write, count == 0 */
+    EXPECT_EQ(((int *)(buf.shm))[0], ((int *)(buf.shm))[1]);
+    EXPECT_EQ(0, ((int *)(buf.shm))[2]);
+
+    /* buffer must still be usable: push/get a further record intact */
+    for (i = 0; i < (int)sizeof(record_b); i++)
+        record_b[i] = (unsigned char)(0xF0 ^ (i & 0xff));
+
+    memset(storage, 0xAA, sizeof(storage));
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record_b, (unsigned int)sizeof(record_b)));
+    EXPECT_EQ((int)sizeof(record_b), dlt_buffer_get(&buf, storage, (int)sizeof(storage), 1));
+
+    for (i = 0; i < (int)sizeof(record_b); i++)
+        EXPECT_EQ(record_b[i], storage[i]);
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_free_dynamic(&buf));
+}
+TEST(t_dlt_buffer_get, negative_max_size_no_copy)
+{
+    /* A negative max_size must not be interpreted as a copy size (cast to
+     * unsigned it would become a huge memcpy): max_size <= 0 means no copy,
+     * keeping the established delete/skip semantics of max_size == 0
+     * (compare dlt_buffer_remove()), which return the record size. */
+    DltBuffer buf;
+    unsigned char record[100];
+    unsigned char storage[100];
+    int i;
+
+    for (i = 0; i < (int)sizeof(record); i++)
+        record[i] = (unsigned char)(i & 0xff);
+
+    memset(storage, 0xAA, sizeof(storage));
+
+    EXPECT_LE(DLT_RETURN_OK,
+              dlt_buffer_init_dynamic(&buf, DLT_USER_RINGBUFFER_MIN_SIZE, DLT_USER_RINGBUFFER_MAX_SIZE,
+                                      DLT_USER_RINGBUFFER_STEP_SIZE));
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_push(&buf, record, (unsigned int)sizeof(record)));
+
+    /* negative max_size: no copy, record is skipped and deleted */
+    EXPECT_EQ((int)sizeof(record), dlt_buffer_get(&buf, storage, -1, 1));
+
+    /* nothing was written to the caller's buffer */
+    for (i = 0; i < (int)sizeof(storage); i++)
+        EXPECT_EQ(0xAA, storage[i]);
+
+    /* record was consumed */
+    EXPECT_EQ(0, dlt_buffer_get_message_count(&buf));
+    EXPECT_GE(-1, dlt_buffer_get(&buf, storage, (int)sizeof(storage), 1));
+
+    EXPECT_LE(DLT_RETURN_OK, dlt_buffer_free_dynamic(&buf));
+}
 /* End Method: dlt_common::dlt_buffer_get */
 
 


### PR DESCRIPTION
## Problem

`dlt_buffer_get()` in `src/shared/dlt_common.c` logs a warning when `head.size > max_size` but still passes `head.size` to `dlt_buffer_read_block()`, writing past the end of the caller's buffer — CWE-119 heap/stack overflow depending on the call site.

Reproducer (from issue #829):
```c
// write block 20% larger than DLT_DAEMON_RCVBUFSIZE
unsigned char write_data[DLT_DAEMON_RCVBUFSIZE + 2004] = {0};
static char data[DLT_DAEMON_RCVBUFSIZE] = {0};

dlt_buffer_push(&buf, write_data, sizeof(write_data));
dlt_buffer_get(&buf, (unsigned char *)data, sizeof(data), 0);
// → writes DLT_DAEMON_RCVBUFSIZE + 2004 bytes into a DLT_DAEMON_RCVBUFSIZE buffer
```

## Fix (`src/shared/dlt_common.c`)

Three changes, one function:

1. **Cap the copy**: introduce `copy_size = min(head.size, max_size)` and pass it to `dlt_buffer_read_block()`.

2. **Ring buffer consistency**: when clipping occurs and `delete=1`, advance the ring buffer read pointer by the full `head.size` (not `copy_size`) so subsequent reads start at the correct position.

3. **Return value**: return `copy_size` instead of `head.size` to correctly report the number of bytes written to the caller's buffer.

**+18 / -10 lines, 1 file.**

Fixes #829.