### PR TITLE
fix(logstorage): decrement g_logstorage_cache_size on filter config free

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -89,6 +89,17 @@ DLT_STATIC void dlt_logstorage_filter_config_free(DltLogStorageFilterConfig *dat
 #endif
 
     if (data->cache != NULL) {
+        unsigned int cache_size = 0;
+        if (DLT_OFFLINE_LOGSTORAGE_IS_STRATEGY_SET(data->sync,
+                DLT_LOGSTORAGE_SYNC_ON_SPECIFIC_SIZE) > 0)
+            cache_size = data->specific_size;
+        else
+            cache_size = data->file_size;
+        cache_size += (unsigned int)sizeof(DltLogStorageCacheFooter);
+        if (g_logstorage_cache_size >= cache_size)
+            g_logstorage_cache_size -= cache_size;
+        else
+            g_logstorage_cache_size = 0;
         free(data->cache);
         data->cache = NULL;
     }


### PR DESCRIPTION
## Problem

`dlt_logstorage_filter_config_free()` calls `free(data->cache)` but never decrements the global `g_logstorage_cache_size` counter.

The counter is incremented during cache allocation in `dlt_logstorage_create_cache()`:
```c
g_logstorage_cache_size += cache_size + sizeof(DltLogStorageCacheFooter);
```

But on the free path the decrement is missing, so the counter grows unboundedly across disable/re-enable cycles. After enough cycles, `g_logstorage_cache_size` reaches `g_max_logstorage_cache_size` even with no active caches, causing all subsequent `dlt_logstorage_create_cache()` calls to fail with "Max cache size reached".

Reported in #778.

## Fix

Before `free(data->cache)`, compute the same `cache_size` value that was used during allocation and subtract it from `g_logstorage_cache_size`. Clamp to zero to guard against any bookkeeping inconsistency.

```c
if (data->cache != NULL) {
    unsigned int cache_size = 0;
    if (DLT_OFFLINE_LOGSTORAGE_IS_STRATEGY_SET(data->sync,
            DLT_LOGSTORAGE_SYNC_ON_SPECIFIC_SIZE) > 0)
        cache_size = data->specific_size;
    else
        cache_size = data->file_size;
    cache_size += (unsigned int)sizeof(DltLogStorageCacheFooter);
    if (g_logstorage_cache_size >= cache_size)
        g_logstorage_cache_size -= cache_size;
    else
        g_logstorage_cache_size = 0;
    free(data->cache);
    data->cache = NULL;
}
```

## Testing

Verified manually: repeated logstorage enable/disable cycles no longer exhaust the cache counter.