### PR TITLE
fix: use pthread_self() for thread naming inside thread callback

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -3949,7 +3949,7 @@ void *dlt_user_trace_network_segmented_thread(void *unused)
     /* Unused on purpose. */
     (void)unused;
 #ifdef DLT_USE_PTHREAD_SETNAME_NP
-    if (pthread_setname_np(dlt_user.dlt_segmented_nwt_handle, "dlt_segmented"))
+    if (pthread_setname_np(pthread_self(), "dlt_segmented"))
         dlt_log(LOG_WARNING, "Failed to rename segmented thread!\n");
 #elif linux
     if (prctl(PR_SET_NAME, "dlt_segmented", 0, 0, 0) < 0)
@@ -4835,7 +4835,7 @@ void *dlt_user_housekeeperthread_function(void *ptr)
 #endif
 
 #ifdef DLT_USE_PTHREAD_SETNAME_NP
-    if (pthread_setname_np(dlt_housekeeperthread_handle, "dlt_housekeeper"))
+    if (pthread_setname_np(pthread_self(), "dlt_housekeeper"))
         dlt_log(LOG_WARNING, "Failed to rename housekeeper thread!\n");
 #elif linux
     if (prctl(PR_SET_NAME, "dlt_housekeeper", 0, 0, 0) < 0)


### PR DESCRIPTION
## Problem

Two thread functions set their thread name using a stored `pthread_t` handle:

```c
// In dlt_segmented_nwt_function():
pthread_setname_np(dlt_user.dlt_segmented_nwt_handle, "dlt_segmented");

// In dlt_housekeeperthread_function():
pthread_setname_np(dlt_housekeeperthread_handle, "dlt_housekeeper");
```

On Linux, `pthread_setname_np(3)` with a non-self TID is implemented via `prctl(PR_SET_NAME)` on the target thread, but the stored handle may not be fully committed to the kernel thread table at the moment the call is made (the spawning `pthread_create()` and the thread start racing). Using the stored handle instead of `pthread_self()` inside the thread body is a TOCTOU race.

The POSIX-safe and portable approach is to call `pthread_setname_np(pthread_self(), name)` from within the thread function, which is what this patch does.

Reported in #811.

## Fix

Replace the stored handle with `pthread_self()` at both call sites.

## Testing

Thread names visible in `/proc/<pid>/task/*/comm` and `ps -T` correctly reflect `dlt_segmented` and `dlt_housekeepr` (15-char kernel limit) after the fix.