### PR TITLE
fix(journal): treat missing PRIORITY field as unknown, not Emergency

### DIFF
--- a/src/system/dlt-system-journal.c
+++ b/src/system/dlt-system-journal.c
@@ -252,7 +252,9 @@ void get_journal_msg(sd_journal *j, DltSystemConfiguration *config)
 
         /* map log level on demand */
         loglevel = DLT_LOG_INFO;
-        systemd_loglevel = atoi(buffer_priority);
+        /* Use -1 as sentinel when PRIORITY field is absent (e.g. auditd entries).
+         * atoi("") would return 0 (Emergency), giving a misleadingly high severity. */
+        systemd_loglevel = (buffer_priority[0] != '\0') ? atoi(buffer_priority) : -1;
 
         if (config->Journal.MapLogLevels) {
             /* Map log levels from journal to DLT */


### PR DESCRIPTION
## Problem

In `get_journal_msg()`, the PRIORITY field is read into `buffer_priority` and then passed to `atoi()`:

```c
dlt_system_journal_get(j, buffer_priority, "PRIORITY", sizeof(buffer_priority));
...
systemd_loglevel = atoi(buffer_priority);
```

When a journal entry has no `PRIORITY` field — common for auditd messages with `_TRANSPORT=audit` — `dlt_system_journal_get()` leaves `buffer_priority` as an empty string. `atoi("")` returns `0`, which maps to severity level 0 (Emergency/Alert/Critical):

```c
case 0:     /* Emergency */
case 1:     /* Alert */
case 2:     /* Critical */
    loglevel = DLT_LOG_FATAL;
```

All auditd log entries are thus emitted as `DLT_LOG_FATAL` with the label "Emergency:", regardless of their actual content.

Fixes #731.

## Fix

Check `buffer_priority[0] != '\0'` before calling `atoi()`. Use `-1` as a sentinel when the field is absent — `-1` does not match any switch case, so the code falls through to `default: loglevel = DLT_LOG_INFO`, and the printed label shows `prio_unknown:` which accurately reflects the missing field.

```c
systemd_loglevel = (buffer_priority[0] != '\0') ? atoi(buffer_priority) : -1;
```

## Testing

Verified: auditd journal entries without PRIORITY are logged at `DLT_LOG_INFO` with label `prio_unknown:` after the fix.