### PR TITLE
docs: sync dlt-adaptor-stdin man page with actual CLI options

### DIFF
--- a/doc/dlt-adaptor-stdin.1.md
+++ b/doc/dlt-adaptor-stdin.1.md
@@ -6,7 +6,7 @@
 
 # SYNOPSIS
 
-**dlt-adaptor-stdin** \[**-a** apid\] \[**-c** ctid\] \[**-b**\] \[**-s**\] \[**-t** timeout\] \[**-h**\]
+**dlt-adaptor-stdin** \[**-a** apid\] \[**-c** ctid\] \[**-b**\] \[**-t** timeout\] \[**-v** level\] \[**-h**\]
 
 # DESCRIPTION
 
@@ -20,15 +20,19 @@ This is a small external program for forwarding input from stdin to DLT Daemon.
 
 -c
 
-:    Set context ID tp ctid (default: SINC)
+:    Set context ID to ctid (default: SINC)
 
 -b
 
-:    To flush the buffered logs while unregistering app
+:    Flush buffered logs before unregistering the application
 
 -t
 
 :    Set timeout when sending messages at exit, in ms (default: 10000 = 10sec)
+
+-v
+
+:    Set verbosity level (default: INFO; accepted values: FATAL ERROR WARN INFO DEBUG VERBOSE)
 
 -h
 
@@ -37,7 +41,7 @@ This is a small external program for forwarding input from stdin to DLT Daemon.
 # EXAMPLES
 
 Forward all dmesg to DLT Daemon without discarding any messages
-    **dmesg | dlt-adaptor-stdin -b -s**
+    **dmesg | dlt-adaptor-stdin -b**
 
 Send DBUS messages to DLT Daemon using the program dbus-monitor
     **dbus-monitor | dlt-adaptor-stdin**


### PR DESCRIPTION
## Problem

The `dlt-adaptor-stdin.1.md` man page was out of sync with the implementation in `src/adaptor/dlt-adaptor-stdin.c` in several ways (as reported in #813):

| Issue | Details |
|-------|---------|
| `-s` option in SYNOPSIS | Doesn't exist — `getopt` string is `"a:c:bht:v:"`, no `-s` |
| `-v level` not documented | Fully implemented: sets verbosity to FATAL/ERROR/WARN/INFO/DEBUG/VERBOSE |
| EXAMPLES uses `-b -s` | The non-existent `-s` is used in the dmesg example |
| Typo in `-c` description | "Set context ID tp ctid" should be "to" |

## Fix

- Remove `-s` from SYNOPSIS
- Add `-v level` to SYNOPSIS and OPTIONS  
- Remove `-s` from EXAMPLES (dmesg pipe example)
- Fix "tp" → "to" typo in `-c` option description
- Clarify `-b` description wording

Fixes #813