### PR TITLE
fix: off-by-one in DLT_MSG_READ_STRING allows dst[length] write past buffer end

### DIFF
--- a/include/dlt/dlt_common.h
+++ b/include/dlt/dlt_common.h
@@ -341,7 +341,7 @@
 
 #   define DLT_MSG_READ_STRING(dst, src, maxlength, dstlength, length) \
     do { \
-        if ((maxlength < 0) || (length <= 0) || (dstlength < length) || (maxlength < length)) \
+        if ((maxlength < 0) || (length <= 0) || (dstlength <= length) || (maxlength < length)) \
         { \
             maxlength = -1; \
         } \


### PR DESCRIPTION
Fixes #616.

### Bug

\`DLT_MSG_READ_STRING\` in \`include/dlt/dlt_common.h\` writes a null terminator at \`dst[length]\` after copying \`length\` bytes into \`dst\`. The guard condition \`dstlength < length\` allows \`dstlength == length\` through to the else branch, where \`dst[length]\` is one past the end of the buffer (valid indices: \`0..dstlength-1\`).

Reproducer (ASAN-confirmed, from issue):
\`\`\`
dlt-convert -a ./poc.dlt
\`\`\`

CWE-193 (Off-by-one).

### Fix

Tighten the guard from \`dstlength < length\` to \`dstlength <= length\`, requiring the destination buffer to hold at least \`length + 1\` bytes before proceeding.

\`\`\`diff
-        if ((maxlength < 0) || (length <= 0) || (dstlength < length) || (maxlength < length)) \
+        if ((maxlength < 0) || (length <= 0) || (dstlength <= length) || (maxlength < length)) \
\`\`\`

**Files**: \`include/dlt/dlt_common.h\` — +1/−1

---
*AI-assisted — authored with Claude, reviewed by Komada.*