### PR TITLE
fix: use pthread_self() in thread callbacks instead of parent-stored handle

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -3949,7 +3949,7 @@ void *dlt_user_trace_network_segmented_thread(void *unused)
     /* Unused on purpose. */
     (void)unused;
 #ifdef DLT_USE_PTHREAD_SETNAME_NP
-    if (pthread_setname_np(dlt_user.dlt_segmented_nwt_handle, "dlt_segmented"))
+    if (pthread_setname_np(pthread_self(), "dlt_segmented"))
         dlt_log(LOG_WARNING, "Failed to rename segmented thread!\n");
 #elif linux
     if (prctl(PR_SET_NAME, "dlt_segmented", 0, 0, 0) < 0)
@@ -4835,7 +4835,7 @@ void *dlt_user_housekeeperthread_function(void *ptr)
 #endif
 
 #ifdef DLT_USE_PTHREAD_SETNAME_NP
-    if (pthread_setname_np(dlt_housekeeperthread_handle, "dlt_housekeeper"))
+    if (pthread_setname_np(pthread_self(), "dlt_housekeeper"))
         dlt_log(LOG_WARNING, "Failed to rename housekeeper thread!\n");
 #elif linux
     if (prctl(PR_SET_NAME, "dlt_housekeeper", 0, 0, 0) < 0)


### PR DESCRIPTION
Fixes #811.

### Bug

Two thread callbacks in \`src/lib/dlt_user.c\` call \`pthread_setname_np\` with a handle stored by the parent thread:

- \`dlt_user_trace_network_segmented_thread\` (line 3952): uses \`dlt_user.dlt_segmented_nwt_handle\`
- \`dlt_user_housekeeperthread_function\` (line 4838): uses \`dlt_housekeeperthread_handle\`

Both handles are written by \`pthread_create\` in the parent. Because the callback begins executing before \`pthread_create\` returns, the handle is zero or uninitialized at the point \`pthread_setname_np\` is called. On musl C (standard in many embedded Linux / Yocto configurations), this causes a coredump.

The callbacks are already running in the target thread — \`pthread_self()\` is the correct and sufficient call.

### Fix

\`\`\`diff
-    if (pthread_setname_np(dlt_user.dlt_segmented_nwt_handle, "dlt_segmented"))
+    if (pthread_setname_np(pthread_self(), "dlt_segmented"))
\`\`\`

\`\`\`diff
-    if (pthread_setname_np(dlt_housekeeperthread_handle, "dlt_housekeeper"))
+    if (pthread_setname_np(pthread_self(), "dlt_housekeeper"))
\`\`\`

**Files**: \`src/lib/dlt_user.c\` — +2/−2

---
*AI-assisted — authored with Claude, reviewed by Komada.*