### PR TITLE
fix(dlt-receive): set SO_RCVTIMEO and SO_KEEPALIVE to enable -r reconnect on half-open TCP

### DIFF
--- a/include/dlt/dlt_client.h
+++ b/include/dlt/dlt_client.h
@@ -107,6 +107,7 @@ typedef struct
     DltClientMode mode;        /**< mode DltClientMode */
     int send_serial_header;    /**< (Boolean) Send DLT messages with serial header */
     int resync_serial_header;  /**< (Boolean) Resync to serial header on all connection */
+    int recv_timeout_sec;      /**< SO_RCVTIMEO timeout in seconds for TCP sockets (0 = blocking, no timeout) */
 } DltClient;
 
 #   ifdef __cplusplus

--- a/src/console/dlt-receive.c
+++ b/src/console/dlt-receive.c
@@ -624,6 +624,12 @@ int main(int argc, char *argv[])
     else{
         dlt_set_id(dltdata.ecuid, DLT_RECEIVE_ECU_ID);}
 
+    /* Set recv timeout equal to the reconnect interval so half-open TCP
+     * connections are detected within one interval rather than blocking
+     * recv() forever.  Minimum 5 s to avoid zero-timeout edge case. */
+    if (dltdata.rflag == 1)
+        dltclient.recv_timeout_sec = (dltdata.rvalue > 0) ? (dltdata.rvalue / 1000) : 5;
+
     while (true) {
         /* Attempt to connect to TCP socket or open serial device */
         if (dlt_client_connect(&dltclient, dltdata.vflag) != DLT_RETURN_ERROR) {

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -97,6 +97,7 @@
 #include <errno.h>
 #include <limits.h>
 #include <poll.h>
+#include <netinet/tcp.h>
 
 #include "dlt_types.h"
 #include "dlt_log.h"
@@ -147,6 +148,7 @@ DltReturnValue dlt_client_init_port(DltClient *client, int port, int verbose)
     client->receiver.buf = NULL;
     client->receiver.backup_buf = NULL;
     client->hostip = NULL;
+    client->recv_timeout_sec = 0;
 
     return DLT_RETURN_OK;
 }
@@ -300,6 +302,44 @@ DltReturnValue dlt_client_connect(DltClient *client, int verbose)
                      "%s: Connected to DLT daemon (%s)\n",
                      __func__,
                      client->servIP);
+        }
+
+        /* Apply receive timeout so half-open TCP is detected and the
+         * reconnect loop (-r) can fire.  recv() with no timeout blocks
+         * forever on a stale connection; SO_RCVTIMEO causes it to return
+         * EAGAIN after the deadline, which dlt_receiver_receive() maps to
+         * a <=0 return, triggering dlt_client_main_loop to exit. */
+        if (client->recv_timeout_sec > 0) {
+            struct timeval tv;
+            tv.tv_sec  = client->recv_timeout_sec;
+            tv.tv_usec = 0;
+            if (setsockopt(client->sock, SOL_SOCKET, SO_RCVTIMEO,
+                           (const char *)&tv, sizeof(tv)) < 0) {
+                dlt_vlog(LOG_WARNING,
+                         "%s: failed to set SO_RCVTIMEO: %s\n",
+                         __func__, strerror(errno));
+            }
+        }
+
+        /* Enable TCP keepalive so the kernel independently probes dead
+         * peers, providing a second line of defence against half-open
+         * connections when no application-level timeout is set. */
+        {
+            int keepalive = 1;
+            if (setsockopt(client->sock, SOL_SOCKET, SO_KEEPALIVE,
+                           &keepalive, sizeof(keepalive)) < 0) {
+                dlt_vlog(LOG_WARNING,
+                         "%s: failed to set SO_KEEPALIVE: %s\n",
+                         __func__, strerror(errno));
+            }
+#ifdef TCP_KEEPIDLE
+            else {
+                int idle = 60, intvl = 10, cnt = 3;
+                setsockopt(client->sock, IPPROTO_TCP, TCP_KEEPIDLE,  &idle,  sizeof(idle));
+                setsockopt(client->sock, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, sizeof(intvl));
+                setsockopt(client->sock, IPPROTO_TCP, TCP_KEEPCNT,   &cnt,   sizeof(cnt));
+            }
+#endif
         }
 
         receiver_type = DLT_RECEIVE_SOCKET;


### PR DESCRIPTION
# fix(dlt-receive): set SO_RCVTIMEO and SO_KEEPALIVE in dlt_client_connect to enable -r reconnect on half-open TCP

Fixes #817.

## Problem

`dlt-receive -r <interval>` is supposed to reconnect automatically when the
DLT daemon becomes unavailable. This works correctly for clean disconnects
(RST/FIN received): `dlt_receiver_receive()` returns ≤0, `dlt_client_main_loop`
exits, and the reconnect loop fires after the specified interval.

However, when the network path fails silently — half-open TCP, common in
VM/container restarts and network partitions — the kernel socket stays in
`ESTABLISHED` state. `dlt_receiver_receive()` calls `recv()` which **blocks
forever**. The reconnect interval is never consulted.

## Fix

Three files changed:

**`include/dlt/dlt_client.h`**: Add `recv_timeout_sec` field to `DltClient`
struct (0 = no timeout, backwards-compatible default).

**`src/lib/dlt_client.c`** — in `dlt_client_connect()`, after blocking mode
is restored on a successful TCP connect:
- If `client->recv_timeout_sec > 0`: call `setsockopt(SO_RCVTIMEO)` with the
  configured timeout. When `recv()` times out it returns -1/EAGAIN, which
  `dlt_receiver_receive()` maps to a ≤0 return, causing `dlt_client_main_loop`
  to exit and the reconnect loop to fire.
- Always set `SO_KEEPALIVE` (+ `TCP_KEEPIDLE`/`TCP_KEEPINTVL`/`TCP_KEEPCNT`
  where available) as a second line of defence.

**`src/console/dlt-receive.c`** — before the reconnect loop: when `-r` is
active, set `dltclient.recv_timeout_sec = rvalue / 1000` (minimum 5 s) so
the socket timeout matches the reconnect interval.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Clean disconnect (RST/FIN) | Reconnect works | Unchanged |
| Half-open TCP (`-r` not set) | `recv()` blocks forever | `recv()` blocks forever (no change — timeout = 0) |
| Half-open TCP (`-r 5000` = 5 s) | `recv()` blocks forever, `-r` ignored | `recv()` times out after 5 s, reconnect fires |

*AI-assisted — authored with Claude, reviewed by Komada.*