### PR TITLE
warnings: Fix clang generated warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,7 +261,11 @@ add_compile_options(
     -Wcast-qual
     -Wno-system-headers
     -Wno-unused-function
-    -Wno-stringop-truncation
+    $<$<AND:$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:Clang>>:-Wno-gnu-statement-expression-from-macro-expansion>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:Clang>>:-Wno-gnu-statement-expression-from-macro-expansion>
+    $<$<CXX_COMPILER_ID:Clang>:-Wno-gnu-zero-variadic-macro-arguments>
+    $<$<AND:$<COMPILE_LANGUAGE:C>,$<C_COMPILER_ID:GNU>>:-Wno-stringop-truncation>
+    $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU>>:-Wno-stringop-truncation>
 )
 
 if(WITH_DOC STREQUAL "OFF")

--- a/examples/example1/example1.c
+++ b/examples/example1/example1.c
@@ -50,7 +50,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa1)
 
-int main()
+int main(void)
 {
     struct timespec ts;
 

--- a/examples/example1_v2/example1.c
+++ b/examples/example1_v2/example1.c
@@ -50,7 +50,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa1);
 
-int main()
+int main(void)
 {
     struct timespec ts;
 

--- a/examples/example2/example2.c
+++ b/examples/example2/example2.c
@@ -52,7 +52,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa2)
 
-int main()
+int main(void)
 {
     int num;
     struct timespec ts;

--- a/examples/example2_v2/example2.c
+++ b/examples/example2_v2/example2.c
@@ -52,7 +52,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa2);
 
-int main()
+int main(void)
 {
     int num;
     struct timespec ts;

--- a/examples/example3/example3.c
+++ b/examples/example3/example3.c
@@ -52,7 +52,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa3)
 
-int main()
+int main(void)
 {
     int num;
     struct timespec ts;

--- a/examples/example3_v2/example3.c
+++ b/examples/example3_v2/example3.c
@@ -52,7 +52,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa3);
 
-int main()
+int main(void)
 {
     int num;
     struct timespec ts;

--- a/examples/example4/example4.c
+++ b/examples/example4/example4.c
@@ -50,7 +50,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa1)
 
-int main()
+int main(void)
 {
     unsigned char buffer[256];
     int num;

--- a/examples/example4_v2/example4.c
+++ b/examples/example4_v2/example4.c
@@ -50,7 +50,7 @@
 
 DLT_DECLARE_CONTEXT(con_exa1);
 
-int main()
+int main(void)
 {
     unsigned char buffer[256];
     int num;

--- a/src/console/dlt-control-v2.c
+++ b/src/console/dlt-control-v2.c
@@ -129,7 +129,7 @@ typedef struct {
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/console/dlt-passive-node-ctrl.c
+++ b/src/console/dlt-passive-node-ctrl.c
@@ -118,7 +118,7 @@ void set_node_id(char *id)
     }
 }
 
-char *get_node_id()
+char *get_node_id(void)
 {
     return g_options.node_id;
 }
@@ -211,7 +211,7 @@ static int dlt_passive_node_analyze_response(char *answer,
  *
  * @return Pointer ot DltControlMsgBody, NULL otherwise
  */
-DltControlMsgBody *dlt_passive_node_prepare_message_body()
+DltControlMsgBody *dlt_passive_node_prepare_message_body(void)
 {
     DltControlMsgBody *mb = calloc(1, sizeof(DltControlMsgBody));
     char *ecuid = get_node_id();
@@ -271,7 +271,7 @@ void dlt_passive_node_destroy_message_body(DltControlMsgBody *msg_body)
  *
  * @return 0 on success, -1 on error
  */
-static int dlt_passive_node_ctrl_single_request()
+static int dlt_passive_node_ctrl_single_request(void)
 {
     int ret = -1;
 
@@ -301,7 +301,7 @@ static int dlt_passive_node_ctrl_single_request()
     return ret;
 }
 
-static void usage()
+static void usage(void)
 {
     printf("Usage: dlt-passive-node-ctrl [options]\n");
     printf("Send a trigger to DLT daemon to (dis)connect a passive node "

--- a/src/console/dlt-receive-v2.c
+++ b/src/console/dlt-receive-v2.c
@@ -144,7 +144,7 @@ typedef struct {
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/console/dlt-sortbytimestamp.c
+++ b/src/console/dlt-sortbytimestamp.c
@@ -194,7 +194,7 @@ void write_messages(int ohandle, DltFile *file,
 /**
  * Print usage information of tool.
  */
-void usage() {
+void usage(void) {
     char version[DLT_VERBUFSIZE];
 
     dlt_get_version(version, DLT_VERBUFSIZE);

--- a/src/console/logstorage/dlt-logstorage-ctrl.c
+++ b/src/console/logstorage/dlt-logstorage-ctrl.c
@@ -354,7 +354,7 @@ static int dlt_logstorage_ctrl_setup_event_loop(void)
  *
  * @return 0 on success, -1 otherwise.
  */
-static int dlt_logstorage_ctrl_single_request()
+static int dlt_logstorage_ctrl_single_request(void)
 {
     int ret = 0;
 

--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -207,7 +207,7 @@ void close_pipes(int fds[2])
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[DLT_DAEMON_TEXTBUFSIZE];
     dlt_get_version(version, DLT_DAEMON_TEXTBUFSIZE);
@@ -2490,7 +2490,7 @@ void dlt_daemon_local_cleanup(DltDaemon *daemon, DltDaemonLocal *daemon_local, i
     free(daemon_local->flags.ipNodes);
 }
 
-void dlt_daemon_exit_trigger()
+void dlt_daemon_exit_trigger(void)
 {
     /* stop event loop */
     g_exit = -1;
@@ -2656,7 +2656,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
 
         msg.storageheadersizev2 = (uint32_t)(STORAGE_HEADER_V2_FIXED_SIZE + strlen(DLT_DAEMON_ECU_ID));
         msg.baseheadersizev2 = BASE_HEADER_V2_FIXED_SIZE;
-        msg.baseheaderextrasizev2 = (int32_t)dlt_message_get_extraparameters_size_v2(msgcontent);
+        msg.baseheaderextrasizev2 = (uint32_t)dlt_message_get_extraparameters_size_v2(msgcontent);
         /* Ecu Id, App Id, Ctx Id and Session Id*/
         msg.extendedheadersizev2 = (uint32_t)(1 + strlen(DLT_DAEMON_ECU_ID) + 1 + strlen(app_id) + 1 + strlen(ctx_id) + sizeof(uint32_t));
 

--- a/src/daemon/dlt-daemon.h
+++ b/src/daemon/dlt-daemon.h
@@ -217,7 +217,7 @@ int dlt_daemon_local_connection_init(DltDaemon *daemon, DltDaemonLocal *daemon_l
 int dlt_daemon_local_ecu_version_init(DltDaemon *daemon, DltDaemonLocal *daemon_local, int verbose);
 
 void dlt_daemon_daemonize(int verbose);
-void dlt_daemon_exit_trigger();
+void dlt_daemon_exit_trigger(void);
 void dlt_daemon_signal_handler(int sig);
 #ifdef __QNX__
 void dlt_daemon_cleanup_timers();

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -817,7 +817,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
 
     msg->storageheadersizev2 = (uint32_t)(STORAGE_HEADER_V2_FIXED_SIZE + (daemon->ecuid2len));
     msg->baseheadersizev2 = BASE_HEADER_V2_FIXED_SIZE;
-    msg->baseheaderextrasizev2 = (int32_t)dlt_message_get_extraparameters_size_v2(DLT_CONTROL_MSG);
+    msg->baseheaderextrasizev2 = (uint32_t)dlt_message_get_extraparameters_size_v2(DLT_CONTROL_MSG);
     msg->extendedheadersizev2 = (uint32_t)((daemon->ecuid2len) + 1 + appidlen + 1 + ctxidlen + 1);
 
     msg->headersizev2 = (int32_t)(msg->storageheadersizev2 + msg->baseheadersizev2 +
@@ -5388,7 +5388,7 @@ void dlt_daemon_control_passive_node_connect_status_v2(int sock,
 
         con = &daemon_local->pGateway.connections[i];
 
-        resp->connection_status[i] = con->status;
+        resp->connection_status[i] = (uint8_t)con->status;
         //TBD: Review node_id[i * con->ecuid2len]
         memcpy(&resp->node_id[i * con->ecuid2len], con->ecuid2, con->ecuid2len);
     }
@@ -5471,7 +5471,7 @@ void dlt_daemon_control_passive_node_connect_status(int sock,
 
         con = &daemon_local->pGateway.connections[i];
 
-        resp->connection_status[i] = con->status;
+        resp->connection_status[i] = (uint8_t)con->status;
         memcpy(&resp->node_id[i * DLT_ID_SIZE], con->ecuid, DLT_ID_SIZE);
     }
 

--- a/src/examples/dlt-example-filetransfer.c
+++ b/src/examples/dlt-example-filetransfer.c
@@ -84,9 +84,10 @@ bool shutdownStatus = false;
  * The function will set the flag (shutdownStatus) to true after .2 sec
  * @return Null to stop thread
  */
-void *cancel_filetransfer()
+void *cancel_filetransfer(void* arg)
 {
     // wait 200msec once a filetransfer is started and then set the flag to true
+    (void)arg;
     struct timespec ts;
     ts.tv_sec = 0;
     ts.tv_nsec = 200000000; // 200 ms
@@ -99,8 +100,9 @@ void *cancel_filetransfer()
  * The function will start dlt filetransfer and will throw error if status of shutdownStatus is high
  * @return Null to stop thread
  */
-void *filetransfer()
+void *filetransfer(void* arg)
 {
+    (void)arg;
     int transferResult;
 
     transferResult = dlt_user_log_file_header(&fileContext, file);
@@ -125,7 +127,7 @@ void *filetransfer()
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/examples/dlt-example-multicast-clientmsg-view.c
+++ b/src/examples/dlt-example-multicast-clientmsg-view.c
@@ -96,7 +96,7 @@ int dlt_receive_message_callback_udp(DltMessage *message)
 {
     static char text[DLT_RECEIVE_TEXTBUFSIZE];
 
-    if ((message == NULL)) {
+    if (message == NULL) {
         printf("NULL message in dlt_receive_message_callback_udp\n");
         return -1;
     }
@@ -119,7 +119,7 @@ int dlt_receive_message_callback_udp(DltMessage *message)
 }
 
 
-int main()
+int main(void)
 {
     struct clientinfostruct clientinfo;
     struct ip_mreq mreq;

--- a/src/examples/dlt-example-user-common-api.c
+++ b/src/examples/dlt-example-user-common-api.c
@@ -66,7 +66,7 @@ DLT_DECLARE_CONTEXT(mycontext)
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/examples/dlt-example-user-func-v2.c
+++ b/src/examples/dlt-example-user-func-v2.c
@@ -84,7 +84,7 @@ DltContextData mycontextdata;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/examples/dlt-example-user-func.c
+++ b/src/examples/dlt-example-user-func.c
@@ -82,7 +82,7 @@ DltContextData mycontextdata;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/examples/dlt-example-user-v2.c
+++ b/src/examples/dlt-example-user-v2.c
@@ -88,7 +88,7 @@ DLT_DECLARE_CONTEXT(mycontext3)
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/examples/dlt-example-user.c
+++ b/src/examples/dlt-example-user.c
@@ -86,7 +86,7 @@ DLT_DECLARE_CONTEXT(mycontext3)
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/lib/dlt_env_ll.c
+++ b/src/lib/dlt_env_ll.c
@@ -125,7 +125,8 @@ int dlt_env_helper_to_lower(char **const env, char *result, int const res_len)
 
 int dlt_env_extract_symbolic_ll(char **const env, int8_t *ll)
 {
-    char result[strlen("verbose") + 1];
+    char result[sizeof("verbose")];
+
 
     if (!env || !ll) {
         return -1;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -545,7 +545,7 @@ DltReturnValue dlt_init(void)
 
     /* Check logging mode and internal log file is opened or not*/
     if (logging_mode == DLT_LOG_TO_FILE && logging_handle == NULL) {
-        dlt_log_init(logging_mode);
+        dlt_log_init((int)logging_mode);
     }
 
     /* Initialize common part of dlt_init()/dlt_init_file() */
@@ -2391,14 +2391,14 @@ DltReturnValue dlt_set_application_ll_ts_limit(DltLogLevelType loglevel, DltTrac
 
     /* Update local structures */
     for (i = 0; i < dlt_user.dlt_ll_ts_num_entries; i++) {
-        dlt_user.dlt_ll_ts[i].log_level = loglevel;
-        dlt_user.dlt_ll_ts[i].trace_status = tracestatus;
+        dlt_user.dlt_ll_ts[i].log_level = (int8_t)loglevel;
+        dlt_user.dlt_ll_ts[i].trace_status = (int8_t)tracestatus;
 
         if (dlt_user.dlt_ll_ts[i].log_level_ptr)
-            *(dlt_user.dlt_ll_ts[i].log_level_ptr) = loglevel;
+            *(dlt_user.dlt_ll_ts[i].log_level_ptr) = (int8_t)loglevel;
 
         if (dlt_user.dlt_ll_ts[i].trace_status_ptr)
-            *(dlt_user.dlt_ll_ts[i].trace_status_ptr) = tracestatus;
+            *(dlt_user.dlt_ll_ts[i].trace_status_ptr) = (int8_t)tracestatus;
     }
 
     dlt_mutex_unlock();
@@ -2413,7 +2413,7 @@ DltReturnValue dlt_set_application_ll_ts_limit(DltLogLevelType loglevel, DltTrac
     }
 }
 
-int dlt_get_log_state()
+int dlt_get_log_state(void)
 {
     return dlt_user.log_state;
 }
@@ -2500,25 +2500,6 @@ DltReturnValue dlt_user_log_write_start_init(DltContext *handle,
     return DLT_RETURN_TRUE;
 }
 
-static DltReturnValue dlt_user_log_write_start_internal(DltContext *handle,
-                                                        DltContextData *log,
-                                                        DltLogLevelType loglevel,
-                                                        uint32_t messageid,
-                                                        bool is_verbose);
-
-inline DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log, DltLogLevelType loglevel)
-{
-    return dlt_user_log_write_start_internal(handle, log, loglevel, DLT_USER_DEFAULT_MSGID, true);
-}
-
-DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
-                                           DltContextData *log,
-                                           DltLogLevelType loglevel,
-                                           uint32_t messageid)
-{
-    return dlt_user_log_write_start_internal(handle, log, loglevel, messageid, false);
-}
-
 DltReturnValue dlt_user_log_write_start_internal(DltContext *handle,
                                            DltContextData *log,
                                            DltLogLevelType loglevel,
@@ -2585,6 +2566,19 @@ DltReturnValue dlt_user_log_write_start_internal(DltContext *handle,
     }
 
     return ret;
+}
+
+inline DltReturnValue dlt_user_log_write_start(DltContext *handle, DltContextData *log, DltLogLevelType loglevel)
+{
+    return dlt_user_log_write_start_internal(handle, log, loglevel, DLT_USER_DEFAULT_MSGID, true);
+}
+
+DltReturnValue dlt_user_log_write_start_id(DltContext *handle,
+                                           DltContextData *log,
+                                           DltLogLevelType loglevel,
+                                           uint32_t messageid)
+{
+    return dlt_user_log_write_start_internal(handle, log, loglevel, messageid, false);
 }
 
 DltReturnValue dlt_user_log_write_start_w_given_buffer(DltContext *handle,
@@ -3746,7 +3740,7 @@ DltReturnValue dlt_user_trace_network_segmented_start(uint32_t *id,
         }
 
         log.args_num = 0;
-        log.trace_status = nw_trace_type;
+        log.trace_status = (int32_t)nw_trace_type;
         log.size = 0;
 
         gettimeofday(&tv, NULL);
@@ -3848,7 +3842,7 @@ DltReturnValue dlt_user_trace_network_segmented_segment(uint32_t id,
         }
 
         log.args_num = 0;
-        log.trace_status = nw_trace_type;
+        log.trace_status = (int32_t)nw_trace_type;
         log.size = 0;
 
         /* Write identifier */
@@ -3917,7 +3911,7 @@ DltReturnValue dlt_user_trace_network_segmented_end(uint32_t id, DltContext *han
         }
 
         log.args_num = 0;
-        log.trace_status = nw_trace_type;
+        log.trace_status = (int32_t)nw_trace_type;
         log.size = 0;
 
         /* Write identifier */
@@ -4184,7 +4178,7 @@ DltReturnValue dlt_user_trace_network_truncated(DltContext *handle,
         }
 
         log.args_num = 0;
-        log.trace_status = nw_trace_type;
+        log.trace_status = (int32_t)nw_trace_type;
         log.size = 0;
 
         if (header == NULL)
@@ -4556,7 +4550,7 @@ DltReturnValue dlt_log_raw_v2(DltContext *handle, DltLogLevelType loglevel, void
     return DLT_RETURN_OK;
 }
 
-DltReturnValue dlt_log_marker()
+DltReturnValue dlt_log_marker(void)
 {
     if (!DLT_USER_INITIALIZED) {
         if (dlt_init() < DLT_RETURN_OK) {
@@ -6299,8 +6293,8 @@ DltReturnValue dlt_send_app_ll_ts_limit(const char *apid, DltLogLevelType loglev
 
     /* set usercontext */
     dlt_set_id(usercontext.apid, apid);       /* application id */
-    usercontext.log_level = loglevel;
-    usercontext.trace_status = tracestatus;
+    usercontext.log_level = (uint8_t)loglevel;
+    usercontext.trace_status = (uint8_t)tracestatus;
 
     if (dlt_user.dlt_is_file)
         return DLT_RETURN_OK;
@@ -6354,8 +6348,8 @@ DltReturnValue dlt_send_app_ll_ts_limit_v2(const char *apid, DltLogLevelType log
     }
     usercontext.apidlen = (uint8_t)apidlen_sz;
     dlt_set_id_v2(usercontext.apid, apid, usercontext.apidlen); /* application id */
-    usercontext.log_level = loglevel;
-    usercontext.trace_status = tracestatus;
+    usercontext.log_level = (uint8_t)loglevel;
+    usercontext.trace_status = (uint8_t)tracestatus;
 
     size_t buffersize = sizeof(uint8_t) + usercontext.apidlen + sizeof(uint8_t) + sizeof(uint8_t);
     uint8_t buffer[DLT_ID_SIZE + 3];
@@ -6435,7 +6429,7 @@ DltReturnValue dlt_user_log_send_log_mode(DltUserLogMode mode, uint8_t version)
     return DLT_RETURN_OK;
 }
 
-DltReturnValue dlt_user_log_send_marker()
+DltReturnValue dlt_user_log_send_marker(void)
 {
     DltUserHeader userheader;
     DltReturnValue ret;
@@ -7349,7 +7343,7 @@ void dlt_user_test_corrupt_message_size(int enable, int16_t size)
 #endif
 
 
-int dlt_start_threads()
+int dlt_start_threads(void)
 {
     struct timespec time_to_wait, single_wait;
     struct timespec now;
@@ -7438,7 +7432,7 @@ int dlt_start_threads()
     return 0;
 }
 
-void dlt_stop_threads()
+void dlt_stop_threads(void)
 {
     int dlt_housekeeperthread_result = 0;
     int joined = 0;
@@ -7510,7 +7504,7 @@ void dlt_stop_threads()
 #endif /* DLT_NETWORK_TRACE_ENABLE */
 }
 
-static void dlt_fork_child_fork_handler()
+static void dlt_fork_child_fork_handler(void)
 {
     g_dlt_is_child = 1;
     dlt_user_init_state = INIT_UNITIALIZED;

--- a/src/offlinelogstorage/dlt_offline_logstorage.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage.c
@@ -1732,7 +1732,7 @@ DLT_STATIC int dlt_daemon_offline_setup_filter_properties(DltLogStorage *handle,
             continue;
 
         /* check value and store temporary */
-        ret = dlt_logstorage_check_param(&tmp_data, i, value);
+        ret = dlt_logstorage_check_param(&tmp_data, (DltLogstorageFilterConfType)i, value);
 
         if (ret != 0) {
             if (tmp_data.apids != NULL) {

--- a/src/shared/dlt_log.c
+++ b/src/shared/dlt_log.c
@@ -113,7 +113,7 @@ DltReturnValue dlt_log_init_multiple_logfiles_support(const DltLoggingMode mode,
     return result;
 }
 
-DltReturnValue dlt_log_init_single_logfile()
+DltReturnValue dlt_log_init_single_logfile(void)
 {
     /* internal logging to file */
     errno = 0;
@@ -333,14 +333,14 @@ void dlt_log_free(void)
     }
 }
 
-void dlt_log_free_single_logfile()
+void dlt_log_free_single_logfile(void)
 {
     if (logging_handle != NULL) {
         fclose(logging_handle);
     }
 }
 
-void dlt_log_free_multiple_logfiles()
+void dlt_log_free_multiple_logfiles(void)
 {
     if (DLT_RETURN_ERROR == multiple_files_buffer_free(&multiple_files_ring_buffer)) return;
 
@@ -348,7 +348,7 @@ void dlt_log_free_multiple_logfiles()
     multiple_files_ring_buffer.ohandle = -1;
 }
 
-bool dlt_is_log_in_multiple_files_active()
+bool dlt_is_log_in_multiple_files_active(void)
 {
     return multiple_files_ring_buffer.ohandle > -1;
 }

--- a/src/system/dlt-system-journal.c
+++ b/src/system/dlt-system-journal.c
@@ -73,7 +73,7 @@ typedef struct
 DLT_IMPORT_CONTEXT(dltsystem)
 DLT_DECLARE_CONTEXT(journalContext)
 
-int journal_checkUserBufferForFreeSpace()
+int journal_checkUserBufferForFreeSpace(void)
 {
     int total_size, used_size;
 
@@ -87,7 +87,7 @@ int journal_checkUserBufferForFreeSpace()
 
 int dlt_system_journal_get(sd_journal *j, char *target, const char *field, size_t max_size)
 {
-    char *data;
+    const char *data;
     size_t length;
     int error_code;
     size_t field_size;
@@ -100,7 +100,9 @@ int dlt_system_journal_get(sd_journal *j, char *target, const char *field, size_
     target[0] = 0;
 
     /* get data from journal */
-    error_code = sd_journal_get_data(j, field, (const void **)&data, &length);
+    const void *tmp;
+    error_code = sd_journal_get_data(j, field, &tmp, &length);
+    data = (const char *)tmp;
 
     /* check if an error */
     if (error_code)

--- a/src/system/dlt-system-process-handling.c
+++ b/src/system/dlt-system-process-handling.c
@@ -72,7 +72,7 @@ volatile uint8_t quit = 0;
 extern s_ft_inotify ino;
 #endif
 
-int daemonize()
+int daemonize(void)
 {
     DLT_LOG(dltsystem, DLT_LOG_DEBUG,
             DLT_STRING("dlt-system-process-handling, daemonize"));

--- a/src/system/dlt-system-shell.c
+++ b/src/system/dlt-system-shell.c
@@ -112,7 +112,7 @@ int dlt_shell_injection_callback(uint32_t service_id, void *data, uint32_t lengt
     return 0;
 }
 
-void init_shell()
+void init_shell(void)
 {
     DLT_LOG(dltsystem, DLT_LOG_DEBUG,
             DLT_STRING("dlt-system-shell, register callback"));

--- a/src/system/dlt-system.h
+++ b/src/system/dlt-system.h
@@ -193,8 +193,8 @@ int read_configuration_file(DltSystemConfiguration *config, char *file_name);
 void cleanup_config(DltSystemConfiguration *config, DltSystemCliOptions *options);
 
 /* For dlt-process-handling.c */
-int daemonize();
-void init_shell();
+int daemonize(void);
+void init_shell(void);
 void dlt_system_signal_handler(int sig);
 
 /* Main function for creating/registering all needed file descriptors and starting the poll for all of them. */

--- a/src/tests/dlt-test-client-v2.c
+++ b/src/tests/dlt-test-client-v2.c
@@ -125,7 +125,7 @@ typedef struct
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-fork-handler-v2.c
+++ b/src/tests/dlt-test-fork-handler-v2.c
@@ -91,7 +91,7 @@ void dlt_log_message(DltContext *context, DltLogLevelType ll, char *text, int32_
 /**
  * @brief sample code for using at_fork-handler
  */
-int main()
+int main(void)
 {
     DltContext mainContext;
     struct timespec timeout, r;

--- a/src/tests/dlt-test-fork-handler.c
+++ b/src/tests/dlt-test-fork-handler.c
@@ -49,7 +49,7 @@ void dlt_log_message(DltContext *context, DltLogLevelType ll, char *text, int32_
 /**
  * @brief sample code for using at_fork-handler
  */
-int main()
+int main(void)
 {
     DltContext mainContext;
     struct timespec timeout, r;

--- a/src/tests/dlt-test-multi-process-v2.c
+++ b/src/tests/dlt-test-multi-process-v2.c
@@ -112,11 +112,11 @@ typedef struct {
 /* Forward declarations */
 void init_params(s_parameters *params);
 void quit_handler(int signum);
-void cleanup();
+void cleanup(void);
 void do_forks(s_parameters params);
 void run_threads(s_parameters params);
 void *do_logging(void *data);
-int wait_for_death();
+int wait_for_death(void);
 
 /* State information */
 volatile sig_atomic_t in_handler = 0;
@@ -323,7 +323,7 @@ void quit_handler(int signum)
 /**
  * Ask the child processes to die
  */
-void cleanup()
+void cleanup(void)
 {
     unsigned int i;
 
@@ -458,7 +458,7 @@ void run_threads(s_parameters params)
 /**
  * Wait for child processes to complete their work.
  */
-int wait_for_death()
+int wait_for_death(void)
 {
     int pids_left = (int) pidcount;
 

--- a/src/tests/dlt-test-multi-process.c
+++ b/src/tests/dlt-test-multi-process.c
@@ -89,11 +89,11 @@ typedef struct {
 /* Forward declarations */
 void init_params(s_parameters *params);
 void quit_handler(int signum);
-void cleanup();
+void cleanup(void);
 void do_forks(s_parameters params);
 void run_threads(s_parameters params);
 void *do_logging(void *arg);
-int wait_for_death();
+int wait_for_death(void);
 
 /* State information */
 volatile sig_atomic_t in_handler = 0;
@@ -300,7 +300,7 @@ void quit_handler(int signum)
 /**
  * Ask the child processes to die
  */
-void cleanup()
+void cleanup(void)
 {
     unsigned int i;
 
@@ -435,7 +435,7 @@ void run_threads(s_parameters params)
 /**
  * Wait for child processes to complete their work.
  */
-int wait_for_death()
+int wait_for_death(void)
 {
     int pids_left = (int) pidcount;
 

--- a/src/tests/dlt-test-non-verbose.c
+++ b/src/tests/dlt-test-non-verbose.c
@@ -58,7 +58,7 @@ DltContextData context_data;
 
 void dlt_user_log_level_changed_callback(char context_id[DLT_ID_SIZE],uint8_t log_level,uint8_t trace_status);
 
-void usage()
+void usage(void)
 {
     char version[DLT_COMMON_BUFFER_LENGTH];
 
@@ -84,7 +84,7 @@ void usage()
 /******************/
 /* The test cases */
 /******************/
-int test_logstorage()
+int test_logstorage(void)
 {
     int delay = LOG_DELAY;
     int i;

--- a/src/tests/dlt-test-preregister-context-v2.c
+++ b/src/tests/dlt-test-preregister-context-v2.c
@@ -72,7 +72,7 @@
 /**
  * @brief sample code for using pre-registered contexts
  */
-int main()
+int main(void)
 {
     DltContext mainContext;
     struct timespec ts;

--- a/src/tests/dlt-test-preregister-context.c
+++ b/src/tests/dlt-test-preregister-context.c
@@ -30,7 +30,7 @@
 /**
  * @brief sample code for using pre-registered contexts
  */
-int main()
+int main(void)
 {
     DltContext mainContext;
     struct timespec ts;

--- a/src/tests/dlt-test-qnx-slogger.c
+++ b/src/tests/dlt-test-qnx-slogger.c
@@ -28,7 +28,7 @@
 #define DELAY 500
 #define LENGTH 100
 
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-stress-client-v2.c
+++ b/src/tests/dlt-test-stress-client-v2.c
@@ -127,7 +127,7 @@ typedef struct
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-stress-user-v2.c
+++ b/src/tests/dlt-test-stress-user-v2.c
@@ -86,7 +86,7 @@ DltContextData context_data;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-stress-v2.c
+++ b/src/tests/dlt-test-stress-v2.c
@@ -104,7 +104,7 @@ char *env_manual_interruption = 0;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-stress.c
+++ b/src/tests/dlt-test-stress.c
@@ -105,7 +105,7 @@ char *env_manual_interruption = 0;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-user-v2.c
+++ b/src/tests/dlt-test-user-v2.c
@@ -142,7 +142,7 @@ DltContextData context_data;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/src/tests/dlt-test-user.c
+++ b/src/tests/dlt-test-user.c
@@ -144,7 +144,7 @@ DltContextData context_data;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 

--- a/tests/dlt_test_receiver.c
+++ b/tests/dlt_test_receiver.c
@@ -107,7 +107,7 @@ int result = 0;
 /**
  * Print usage information of tool.
  */
-void usage()
+void usage(void)
 {
     char version[255];
 


### PR DESCRIPTION
This patch ensures that it can compile with clang-22