### PR TITLE
dlt-daemon.c: fix wrong len

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -4111,7 +4111,7 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
             to_remove = (uint32_t) temp;
         }
 
-        len = 0;
+        len = userapp.description_length;
 
         if (len > DLT_DAEMON_DESCSIZE) {
             len = DLT_DAEMON_DESCSIZE;


### PR DESCRIPTION
Set len to 0 makes the application description always empty. One of the failure case:
running "dlt-example-user 'test'",
check "dlt-control -j localhost" will not get application description: APID:LOG-

Expected:
APID:LOG- Test Application for Logging