### PR TITLE
Fix 32-bit time_t compile errors in DLTv2 timestamp code

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -2715,7 +2715,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
 #else
         struct timespec ts;
         if(clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-            msg.headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+            msg.headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
             msg.headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
             msg.headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
             msg.headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);
@@ -2724,7 +2724,7 @@ int dlt_daemon_log_internal(DltDaemon *daemon, DltDaemonLocal *daemon_local,
                 msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
             }
         }else if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-            msg.headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+            msg.headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
             msg.headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
             msg.headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
             msg.headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -876,7 +876,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
 #else
     struct timespec ts;
     if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-        msg->headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+        msg->headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
         msg->headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
         msg->headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
         msg->headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);
@@ -885,7 +885,7 @@ int dlt_daemon_client_send_control_message_v2(int sock,
             msg->headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
         }
     } else if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-        msg->headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+        msg->headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
         msg->headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
         msg->headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
         msg->headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);

--- a/src/lib/dlt_client.c
+++ b/src/lib/dlt_client.c
@@ -1030,7 +1030,7 @@ DltReturnValue dlt_client_send_ctrl_msg_v2(DltClient *client, char *apid, char *
     #else
     struct timespec ts;
     if(clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-        msg.headerextrav2.seconds[0]=(ts.tv_sec >> 32) & 0xFF;
+        msg.headerextrav2.seconds[0]=((uint64_t)ts.tv_sec >> 32) & 0xFF;
         msg.headerextrav2.seconds[1]=(ts.tv_sec >> 24) & 0xFF;
         msg.headerextrav2.seconds[2]=(ts.tv_sec >> 16) & 0xFF;
         msg.headerextrav2.seconds[3]=(ts.tv_sec >> 8) & 0xFF;
@@ -1039,7 +1039,7 @@ DltReturnValue dlt_client_send_ctrl_msg_v2(DltClient *client, char *apid, char *
             msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
         }
     }else if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-        msg.headerextrav2.seconds[0]=(ts.tv_sec >> 32) & 0xFF;
+        msg.headerextrav2.seconds[0]=((uint64_t)ts.tv_sec >> 32) & 0xFF;
         msg.headerextrav2.seconds[1]=(ts.tv_sec >> 24) & 0xFF;
         msg.headerextrav2.seconds[2]=(ts.tv_sec >> 16) & 0xFF;
         msg.headerextrav2.seconds[3]=(ts.tv_sec >> 8) & 0xFF;

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -5465,7 +5465,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
     #else
         struct timespec ts;
         if(clock_gettime(CLOCK_REALTIME, &ts) == 0) {
-            msg.headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+            msg.headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
             msg.headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
             msg.headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
             msg.headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);
@@ -5474,7 +5474,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
                 msg.headerextrav2.nanoseconds = (uint32_t) ts.tv_nsec; /* value is long */
             }
         }else if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-            msg.headerextrav2.seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+            msg.headerextrav2.seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
             msg.headerextrav2.seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
             msg.headerextrav2.seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
             msg.headerextrav2.seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);
@@ -5617,7 +5617,7 @@ DltReturnValue dlt_user_log_send_log_v2(DltContextData *log, const int mtype, Dl
             /* Check filesize */
             /* Return error if the file size has reached to maximum */
             unsigned int msg_size = 0;
-            if (st.st_size < 0 || st.st_size > UINT_MAX) {
+            if (st.st_size < 0 || (uintmax_t)st.st_size > UINT_MAX) {
                 dlt_vlog(LOG_ERR, "%s: File size (%lld bytes) is invalid or too large for unsigned int\n", __func__, (long long int)st.st_size);
                 return DLT_RETURN_FILESZERR;
             }

--- a/src/shared/dlt_common.c
+++ b/src/shared/dlt_common.c
@@ -1081,7 +1081,7 @@ DltReturnValue dlt_message_header_flags(DltMessage *msg, char *text, size_t text
 
     if ((flags & DLT_HEADER_SHOW_TIME) == DLT_HEADER_SHOW_TIME) {
         /* print received time */
-        time_t tt = msg->storageheader->seconds;
+        time_t tt = (time_t)msg->storageheader->seconds;
         tzset();
         localtime_r(&tt, &timeinfo);
         strftime (buffer, sizeof(buffer), "%Y/%m/%d %H:%M:%S", &timeinfo);
@@ -3649,7 +3649,7 @@ DltReturnValue dlt_set_storageheader_v2(DltStorageHeaderV2 *storageheader, uint8
 #if defined(_MSC_VER)
     storageheader->nanoseconds = 0;
 #else
-    storageheader->seconds[0]=(uint8_t)((ts.tv_sec >> 32) & 0xFF);
+    storageheader->seconds[0]=(uint8_t)(((uint64_t)ts.tv_sec >> 32) & 0xFF);
     storageheader->seconds[1]=(uint8_t)((ts.tv_sec >> 24) & 0xFF);
     storageheader->seconds[2]=(uint8_t)((ts.tv_sec >> 16) & 0xFF);
     storageheader->seconds[3]=(uint8_t)((ts.tv_sec >> 8) & 0xFF);


### PR DESCRIPTION
## Summary

On platforms where `time_t` is 32-bit (e.g. armv7 Linux with default `_FILE_OFFSET_BITS`), several DLTv2 timestamp call sites trigger `-Werror=shift-count-overflow`, `-Werror=sign-conversion`, or `-Werror=sign-compare`, preventing compilation with the `-Werror` flags the project sets in its top-level `CMakeLists.txt`.

## Fixes

- **`ts.tv_sec >> 32`** (9 sites across `dlt-daemon.c`, `dlt_daemon_client.c`, `dlt_client.c`, `dlt_user.c`, `dlt_common.c`) — cast `ts.tv_sec` to `uint64_t` before the shift. On 32-bit `time_t` the shift was undefined behavior; on ARM it silently wrapped to `>> 0` due to the 5-bit shift-count mask, which meant `seconds[0]` in the 40-bit DLTv2 timestamp carried a duplicate of the low byte instead of the expected 0. After the cast the top byte is correctly 0 on 32-bit platforms. No behavior change on 64-bit platforms.

- **`time_t tt = msg->storageheader->seconds`** (`dlt_common.c:1084`) — explicit `(time_t)` cast to silence `-Wsign-conversion` when `time_t` is signed 32-bit and `storageheader->seconds` is `uint32_t`.

- **`st.st_size > UINT_MAX`** (`dlt_user.c:5620`) — cast `st.st_size` to `uintmax_t` for the comparison to avoid `-Wsign-compare` between `off_t` (signed long) and `unsigned int`. The preceding `st.st_size < 0` check still guards the cast.

## Test plan

- [x] Cross-compiled `dlt` and `dlt-daemon` for armv7 Linux (glibc, 32-bit `time_t`) with `-Werror -Wfatal-errors -Wconversion -Wshadow -Wundef -Wcast-qual` — clean build and install.
- [x] Verified clean build and install on x86_64 Linux (native, 64-bit `time_t`).
- [ ] DLTv2 wire-format timestamp verified correct on 32-bit target (top byte = 0).