### PR TITLE
fix: add missing <thread> include in dlt-qnx-slogger2-adapter.cpp

### DIFF
--- a/src/dlt-qnx-system/dlt-qnx-slogger2-adapter.cpp
+++ b/src/dlt-qnx-system/dlt-qnx-slogger2-adapter.cpp
@@ -28,6 +28,7 @@
 #include <sys/slog2.h>
 #include <sys/json.h>
 #include <slog2_parse.h>
+#include <thread>
 #include <atomic>
 #include <set>
 


### PR DESCRIPTION
Restores required header for std::this_thread::sleep_for after it was removed in a previous change, fixing build failure.