### PR TITLE
daemon: fix OOB read and parse bug in dlt_daemon_control_get_log_info_v2 (closes #870)

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2151,10 +2151,30 @@ void dlt_daemon_control_get_log_info_v2(int sock,
     db_offset = db_offset + (int)sizeof(uint8_t);
     memcpy(&(req->apidlen), msg->databuffer + db_offset, sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+
+    /* apidlen and ctidlen are attacker-controlled (uint8_t each, up to 255).
+     * The fixed-size precheck at the top of this function only validates
+     * the empty case (apidlen = ctidlen = 0); before reading the
+     * variable-length apid (apidlen bytes) followed by ctidlen (1 byte),
+     * confirm the message is large enough to contain them. Otherwise
+     * dlt_set_id_v2() reads past msg->databuffer. */
+    if ((db_offset + (int)req->apidlen + (int)sizeof(uint8_t)) > msg->datasize) {
+        free(req);
+        return;
+    }
+
     dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
     db_offset = db_offset + (int)req->apidlen;
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+
+    /* Same check for ctid (ctidlen bytes) and the trailing com field
+     * (DLT_ID_SIZE bytes). */
+    if ((db_offset + (int)req->ctidlen + DLT_ID_SIZE) > msg->datasize) {
+        free(req);
+        return;
+    }
+
     dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
     db_offset = db_offset + (int)req->ctidlen;
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2145,6 +2145,8 @@ void dlt_daemon_control_get_log_info_v2(int sock,
 
     /* prepare pointer to message request */
     int db_offset = 0;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     memcpy(&(req->service_id), msg->databuffer + db_offset, sizeof(uint32_t));
     db_offset = db_offset + (int)sizeof(uint32_t);
     memcpy(&(req->options), msg->databuffer + db_offset, sizeof(uint8_t));
@@ -2163,8 +2165,19 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         return;
     }
 
-    dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
-    db_offset = db_offset + (int)req->apidlen;
+    /* Copy the variable-length apid into a local fixed-size buffer through the
+     * dlt_set_id_v2() helper, then point req->apid at it. req->apid is a
+     * calloc'd char * (NULL), so the previous dlt_set_id_v2(req->apid, ...)
+     * call here was a no-op: req->apid stayed NULL and was later passed to
+     * dlt_daemon_application_find_v2() despite req->apidlen being non-zero,
+     * silently turning every non-empty apid lookup into a zero-length one.
+     * Giving the helper a real destination keeps id initialisation inside the
+     * shared API rather than hand-parsing the wire buffer. See #870. */
+    if (req->apidlen > 0) {
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + db_offset), req->apidlen);
+        req->apid = apid_buf;
+        db_offset = db_offset + (int)req->apidlen;
+    }
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
 
@@ -2175,8 +2188,11 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         return;
     }
 
-    dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
-    db_offset = db_offset + (int)req->ctidlen;
+    if (req->ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + db_offset), req->ctidlen);
+        req->ctid = ctid_buf;
+        db_offset = db_offset + (int)req->ctidlen;
+    }
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);
 
     /* initialise new message */


### PR DESCRIPTION
## Problem

`dlt_daemon_control_get_log_info_v2` had two compounding bugs, each
addressed by one commit in this PR.

### 1. Out-of-bounds read parsing apidlen / ctidlen

The fixed-size precheck only validated the 11-byte minimum
GET_LOG_INFO V2 request before the function read two attacker-
controlled `uint8_t` length fields (`apidlen`, `ctidlen`) and used
them to advance an offset into `msg->databuffer`. A short message
with non-zero length fields caused the variable-length reads to walk
past the end of `msg->databuffer` (up to ~514 bytes). Reachable from
any client able to talk to the daemon's control socket. Bounded OOB
read; no OOB write.

### 2. Function never actually parses apid / ctid (#870)

`req` is calloc'd, so its `char *apid` / `char *ctid` pointer fields
start NULL. The `dlt_set_id_v2(req->apid, ...)` calls intended to
populate them are no-ops (the helper early-returns when its
destination is NULL). `req->apid` / `req->ctid` therefore stayed
NULL and were passed to `dlt_daemon_application_find_v2` /
`dlt_daemon_context_find_v2` with non-zero corresponding lengths —
turning every non-empty apid / ctid lookup into a zero-length one.
Full analysis in #870.

## Fix

Two commits:

1. **Bounds checks** after each variable-length field is parsed,
   freeing the calloc'd `req` and returning when the message cannot
   satisfy the next read.
2. **Replace the no-op `dlt_set_id_v2(req->apid, ...)` calls with
   conditional pointer assignments** into `msg->databuffer`,
   mirroring the surgical approach taken for `set_log_level_v2` in
   #864 and `unregister_context_v2` in #868.

`req` shares storage with the message buffer for the duration of
this function call, so the pointer-into-databuffer assignments are
lifetime-safe.

## Notes

- Together with #864, #868, and #869, this completes the V2
  control-handler family cleanup enumerated in #866.
- The function has pre-existing leak paths on other early returns
  (the calloc'd `req` is freed only on the normal exit ~line 2532).
  Not addressed here to keep scope focused — could be a separate
  cleanup PR.

Closes #870.
Related: #866 (META).