### PR TITLE
daemon: fix out-of-bounds read in dlt_daemon_control_set_log_level_v2

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -3682,10 +3682,26 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint32_t);
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+
+    /* apidlen and ctidlen are attacker-controlled (uint8_t each, up to 255).
+     * The fixed-size precheck at the top of this function only validates
+     * the empty case (apidlen = ctidlen = 0); before reading the
+     * variable-length apid (apidlen bytes) followed by ctidlen (1 byte),
+     * confirm the message is large enough to contain them. Otherwise
+     * dlt_set_id_v2() reads past msg->databuffer. */
+    if ((offset + (int)req.apidlen + (int)sizeof(uint8_t)) > msg->datasize)
+        return;
+
     dlt_set_id_v2(req.apid, (const char *)(msg->databuffer + offset), req.apidlen);
     offset = offset + req.apidlen;
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+
+    /* Same check for ctid (ctidlen bytes), the trailing log_level byte,
+     * and the com field (DLT_ID_SIZE bytes). */
+    if ((offset + (int)req.ctidlen + (int)sizeof(uint8_t) + DLT_ID_SIZE) > msg->datasize)
+        return;
+
     dlt_set_id_v2(req.ctid, (const char *)(msg->databuffer + offset), req.ctidlen);
     offset = offset + req.ctidlen;
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));


### PR DESCRIPTION
## Problem

Same shape as #861, applied to the parallel SET_LOG_LEVEL V2 handler.

`dlt_daemon_control_set_log_level_v2` validates only the 11-byte fixed
portion of the SET_LOG_LEVEL V2 request before reading two attacker-
controlled `uint8_t` length fields (`apidlen`, `ctidlen`) and using
them to advance a buffer offset. A short message with non-zero length
fields causes `dlt_set_id_v2()`, the trailing 1-byte `log_level` read,
and the final 4-byte `memcpy()` of the `com` field to read past the
end of `msg->databuffer`. Reachable from any client that can talk to
the daemon's control socket. Bounded OOB read; no OOB write.

## Fix

Two bounds checks:
- After `apidlen` is parsed, verify the message contains
  `apidlen + 1` more bytes (apid + the upcoming `ctidlen` byte).
- After `ctidlen` is parsed, verify the message contains
  `ctidlen + 1 + DLT_ID_SIZE` more bytes (ctid + log_level + com).

Unlike `dlt_daemon_control_get_log_info_v2` in #861, the request struct
here lives on the stack, so no allocation cleanup is required on the
early returns.

## Notes

- Natural follow-up to #861. Functionally independent — can be merged
  in either order.
- I noticed but did **not** address a separate, independent bug in this
  function: at lines 3719/3721 the local `apid`/`ctid` pointers
  (declared NULL at 3687/3688) are passed to `dlt_set_id_v2()` while
  still NULL, so the call is a no-op, yet line 3723 (and later
  branches) dereferences them: `apid[apid_length - 1]`. This NULL-
  derefs whenever `apid_length != 0`. Looks like the intent was
  `apid = req.apid;` (pointer assignment). Filing separately since
  it's an orthogonal bug class.