### PR TITLE
daemon: parse apid/ctid in dlt_daemon_control_set_log_level_v2

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -3682,12 +3682,23 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint32_t);
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    dlt_set_id_v2(req.apid, (const char *)(msg->databuffer + offset), req.apidlen);
-    offset = offset + req.apidlen;
+
+    /* Point req.apid into msg->databuffer when apidlen > 0; leave NULL
+     * otherwise. The previous dlt_set_id_v2(req.apid, ...) call was a
+     * no-op because req.apid is a zero-initialised NULL char *.
+     * See #863 for full analysis. */
+    if (req.apidlen > 0) {
+        req.apid = (char *)(msg->databuffer + offset);
+        offset = offset + req.apidlen;
+    }
+
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    dlt_set_id_v2(req.ctid, (const char *)(msg->databuffer + offset), req.ctidlen);
-    offset = offset + req.ctidlen;
+
+    if (req.ctidlen > 0) {
+        req.ctid = (char *)(msg->databuffer + offset);
+        offset = offset + req.ctidlen;
+    }
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
     memcpy(&(req.com), msg->databuffer + offset, DLT_ID_SIZE);
@@ -3695,10 +3706,14 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     if (daemon_local->flags.enforceContextLLAndTS)
         req.log_level = (uint8_t) getStatus(req.log_level, daemon_local->flags.contextLogLevel);
 
+    /* The earlier dlt_set_id_v2(apid, req.apid, ...) call was a no-op
+     * because the local apid (declared NULL above) was passed as the
+     * destination. With req.apid now correctly assigned, point the
+     * local pointer at it. Same for ctid. */
+    apid = req.apid;
     apid_length = (int8_t) req.apidlen;
-    dlt_set_id_v2(apid, req.apid, req.apidlen);
+    ctid = req.ctid;
     ctid_length = (int8_t) req.ctidlen;
-    dlt_set_id_v2(ctid, req.ctid, req.ctidlen);
 
     if ((apid_length != 0) && (apid[apid_length - 1] == '*') && (ctid == NULL)) { /*apid provided having '*' in it and ctid is null*/
         dlt_daemon_find_multiple_context_and_send_log_level_v2(sock,

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -3666,6 +3666,8 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     PRINT_FUNCTION_VERBOSE(verbose);
     char *apid =NULL;
     char *ctid =NULL;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     DltServiceSetLogLevelV2 req = {0};
     DltDaemonContext *context = NULL;
     int8_t apid_length = 0;
@@ -3683,12 +3685,15 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
 
-    /* Point req.apid into msg->databuffer when apidlen > 0; leave NULL
-     * otherwise. The previous dlt_set_id_v2(req.apid, ...) call was a
-     * no-op because req.apid is a zero-initialised NULL char *.
-     * See #863 for full analysis. */
+    /* Copy the variable-length apid into a local fixed-size buffer through the
+     * dlt_set_id_v2() helper. req.apid is a NULL char * in the zero-initialised
+     * request struct, so the previous dlt_set_id_v2(req.apid, ...) call was a
+     * silent no-op that left req.apid NULL and crashed the daemon downstream.
+     * Giving the helper a real destination keeps id initialisation inside the
+     * shared API rather than hand-parsing the wire buffer. See #863. */
     if (req.apidlen > 0) {
-        req.apid = (char *)(msg->databuffer + offset);
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + offset), req.apidlen);
+        req.apid = apid_buf;
         offset = offset + req.apidlen;
     }
 
@@ -3696,7 +3701,8 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint8_t);
 
     if (req.ctidlen > 0) {
-        req.ctid = (char *)(msg->databuffer + offset);
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + offset), req.ctidlen);
+        req.ctid = ctid_buf;
         offset = offset + req.ctidlen;
     }
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));
@@ -3706,10 +3712,9 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     if (daemon_local->flags.enforceContextLLAndTS)
         req.log_level = (uint8_t) getStatus(req.log_level, daemon_local->flags.contextLogLevel);
 
-    /* The earlier dlt_set_id_v2(apid, req.apid, ...) call was a no-op
-     * because the local apid (declared NULL above) was passed as the
-     * destination. With req.apid now correctly assigned, point the
-     * local pointer at it. Same for ctid. */
+    /* req.apid / req.ctid now reference the local buffers (or stay NULL when
+     * the corresponding length is zero), so the local pointers used by the
+     * lookup logic below can simply alias them. */
     apid = req.apid;
     apid_length = (int8_t) req.apidlen;
     ctid = req.ctid;

--- a/tests/gtest_dlt_common_v2.cpp
+++ b/tests/gtest_dlt_common_v2.cpp
@@ -1557,6 +1557,72 @@ TEST(t_dlt_message_argument_print_v2, nullpointer)
 /* End Method:dlt_common::dlt_message_argument_print_v2 */
 
 
+/* Begin Method:dlt_common::dlt_set_id_v2 */
+TEST(t_dlt_set_id_v2, normal)
+{
+    char id[DLT_V2_ID_SIZE];
+
+    /* Exact length copy populates the destination buffer. This is the
+     * behaviour the V2 control handlers rely on: the previous handler code
+     * passed a NULL char * destination, which silently no-oped (#863/#866). */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "ABCD", 4);
+    EXPECT_EQ(0, memcmp(id, "ABCD", 4));
+    EXPECT_EQ('\0', id[4]);
+
+    /* Single character id. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "X", 1);
+    EXPECT_EQ('X', id[0]);
+    EXPECT_EQ('\0', id[1]);
+
+    /* A length longer than the text stops at the embedded terminator. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "AB", 8);
+    EXPECT_EQ(0, memcmp(id, "AB", 2));
+    EXPECT_EQ('\0', id[2]);
+}
+
+TEST(t_dlt_set_id_v2, truncation)
+{
+    /* The length argument is a uint8_t, so the maximum value (255) equals
+     * DLT_V2_ID_SIZE and is exactly the cap boundary. Fill the whole
+     * destination and use a trailing guard byte to detect any write past
+     * the buffer end. */
+    struct {
+        char id[DLT_V2_ID_SIZE];
+        char guard;
+    } b;
+    char src[DLT_V2_ID_SIZE];
+
+    memset(src, 'Z', sizeof(src));
+    b.guard = 'G';
+    memset(b.id, 0xAA, sizeof(b.id));
+
+    dlt_set_id_v2(b.id, src, (uint8_t)DLT_V2_ID_SIZE);
+
+    for (int i = 0; i < DLT_V2_ID_SIZE; i++)
+        EXPECT_EQ('Z', b.id[i]);
+    EXPECT_EQ('G', b.guard);
+}
+
+TEST(t_dlt_set_id_v2, nullpointer)
+{
+    char id[DLT_V2_ID_SIZE] = {0};
+
+    /* Must tolerate NULL/zero arguments without crashing and without
+     * touching the destination. */
+    EXPECT_NO_THROW(dlt_set_id_v2(NULL, "ABCD", 4));
+    EXPECT_NO_THROW(dlt_set_id_v2(id, NULL, 4));
+    EXPECT_NO_THROW(dlt_set_id_v2(NULL, NULL, 0));
+
+    /* len == 0 leaves the destination untouched. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "ABCD", 0);
+    EXPECT_EQ((char)0xAA, id[0]);
+}
+/* End Method:dlt_common::dlt_set_id_v2 */
+
 
 /*##############################################################################################################################*/
 /*##############################################################################################################################*/


### PR DESCRIPTION
## Problem

`dlt_daemon_control_set_log_level_v2` never actually parsed the
`apid` / `ctid` fields out of incoming SET_LOG_LEVEL V2 requests:

- `req.apid` / `req.ctid` (declared `char *` in
  `DltServiceSetLogLevelV2`) are zero-initialised to NULL.
- The two `dlt_set_id_v2()` calls intended to populate them were
  no-ops because `dlt_set_id_v2` early-returns when its destination is
  NULL.
- Subsequent code at the wildcard / "apid only" / "ctid only" branches
  dereferences the still-NULL local `apid` / `ctid`
  (`apid[apid_length - 1]` etc.) when their length is non-zero,
  crashing the daemon.

Reachable from any client that can talk to the control socket
(dispatched from `dlt_daemon_handle_control_messages_v2`).

Full analysis in #863.

## Fix

When each length field is non-zero, point `req.apid` / `req.ctid`
directly into `msg->databuffer`. Then assign the local `apid` / `ctid`
pointers via plain assignment so the existing branch logic (which keys
off `apid == NULL` / `ctid == NULL`) operates on real values.

`req` shares storage with the message buffer only for the duration of
this function call, so the pointer-into-databuffer trick is lifetime-
safe.

## Notes

- This PR is independent of #862 (the OOB-read fix in the same
  function): they touch overlapping lines but not in conflicting
  ways. Whichever lands first, the other rebases trivially.
- I have not added a unit test because the function is exercised only
  end-to-end with a live daemon and crafted control messages. Happy to
  add one if maintainers can point me at the right harness.

Closes #863.