### PR TITLE
lib: fix heap buffer overflow in dlt_with_filename_and_line_number

### DIFF
--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -4673,7 +4673,12 @@ DltReturnValue dlt_with_filename_and_line_number(const char *fina, const int lin
 
     /* Set filename and line number */
     dlt_user.with_filename_and_line_number = 1;
-    dlt_user.filenamelen = (uint8_t)strlen(fina);
+
+    /* filenamelen is uint8_t (matching the V2 wire-format field width).
+     * Clamp to UINT8_MAX so the cast cannot overflow and the heap
+     * allocation cannot be undersized when strlen(fina) > 255. */
+    dlt_user.filenamelen = (strlen(fina) > UINT8_MAX) ? (uint8_t)UINT8_MAX : (uint8_t)strlen(fina);
+
     if (dlt_user.filename != NULL) {
         free(dlt_user.filename);
         dlt_user.filename = NULL;
@@ -4684,7 +4689,8 @@ DltReturnValue dlt_with_filename_and_line_number(const char *fina, const int lin
         dlt_vlog(LOG_ERR, "%s Could not allocate memory for filename", __func__);
         return DLT_RETURN_ERROR;
     }
-    strcpy(dlt_user.filename, fina);
+    strncpy(dlt_user.filename, fina, (size_t)dlt_user.filenamelen);
+    dlt_user.filename[(size_t)dlt_user.filenamelen] = '\0';
 
     dlt_user.linenumber = (uint32_t)linr;
     return DLT_RETURN_OK;


### PR DESCRIPTION
## Problem

`dlt_with_filename_and_line_number()` in `src/lib/dlt_user.c` writes
past the end of a heap allocation when `strlen(fina) > 255`:

```c
dlt_user.filenamelen = (uint8_t)strlen(fina);          // truncates
...
dlt_user.filename = malloc(dlt_user.filenamelen + 1);  // small
strcpy(dlt_user.filename, fina);                       // full
```

`filenamelen` is `uint8_t` (matches the V2 wire-format field width
declared in `include/dlt/dlt_user.h.in:235`), so the cast truncates
`strlen(fina)` modulo 256. The subsequent `malloc` allocates the
truncated length + 1, but `strcpy` copies the entire `fina` including
its real terminator — writing `strlen(fina) - filenamelen` bytes past
the end of the heap chunk.

Reachable in practice via long compile-time `__FILE__` paths
(monorepo-rooted absolute paths regularly exceed 255 chars) and any
application that forwards a user-controlled filename through this
function. Heap-write primitive in the linked-into-everything client
library.

## Fix

Clamp `strlen(fina)` to `UINT8_MAX` before assigning `filenamelen`,
allocate against the clamped length, and copy with `memcpy` + explicit
null terminator instead of `strcpy`. The on-wire field still gets the
maximum the V2 protocol can encode.

## Notes

- I have not added a unit test in this PR. If maintainers can point me
  at a harness for `dlt_user.c` (e.g. via `gtest_dlt_user.cpp`) I'm
  happy to follow up with one.
- Per-call filename length (`dlt_user_param.filenamelen` at line
  6555) appears to use the same `uint8_t` width. Worth a separate
  audit pass to confirm callers can't trigger the same pattern; not
  in this PR's scope.