### PR TITLE
daemon: fix multi-bug response builder in dlt_daemon_control_message_unregister_context_v2 (closes #867)

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2815,10 +2815,9 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
                                                   int verbose)
 {
     DltMessageV2 msg;
-    DltServiceUnregisterContextV2 resp;
-    uint8_t contextSize = 0;
-    resp.apid = NULL;
-    resp.ctid = NULL;
+    /* Zero-initialise the entire response struct so apidlen / ctidlen
+     * cannot leak uninitialised stack memory to the wire (see #867 / #866). */
+    DltServiceUnregisterContextV2 resp = {0};
     int offset = 0;
 
     PRINT_FUNCTION_VERBOSE(verbose);
@@ -2830,10 +2829,33 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
     if (dlt_message_init_v2(&msg, 0) == DLT_RETURN_ERROR)
         return -1;
 
-    /* prepare payload of data */
-    contextSize = (uint8_t)(sizeof(uint32_t) + sizeof(uint8_t) + sizeof(uint8_t) + apidlen + sizeof(uint8_t) + ctidlen + DLT_ID_SIZE);
+    /* Populate response fields from the function parameters. The
+     * DltServiceUnregisterContextV2 struct uses `char *` for apid / ctid;
+     * point them at the caller-supplied buffers (which outlive this call).
+     * Previously these fields were left NULL while dlt_set_id_v2() was
+     * called with the NULL destination, which is a no-op — the apid /
+     * ctid bytes were never copied into the response. resp.apidlen and
+     * resp.ctidlen were also never assigned, so the subsequent memcpy of
+     * &(resp.apidlen) / &(resp.ctidlen) wrote uninitialised stack memory
+     * to the wire. See #866 for context on the broader pattern. */
+    resp.service_id = DLT_SERVICE_ID_UNREGISTER_CONTEXT;
+    resp.status     = DLT_SERVICE_RESPONSE_OK;
+    resp.apidlen    = apidlen;
+    resp.apid       = apid;
+    resp.ctidlen    = ctidlen;
+    resp.ctid       = ctid;
+    dlt_set_id(resp.comid, comid);
 
-    msg.datasize = contextSize;
+    /* prepare payload of data — use a wider type so the size calculation
+     * cannot overflow when apidlen + ctidlen approach their uint8_t maxima.
+     * Previously a (uint8_t) cast wrapped mod 256, underallocating
+     * msg.databuffer and corrupting the heap on the memcpy chain below. */
+    uint32_t contextSize = (uint32_t)sizeof(uint32_t) + (uint32_t)sizeof(uint8_t)
+                         + (uint32_t)sizeof(uint8_t) + (uint32_t)apidlen
+                         + (uint32_t)sizeof(uint8_t) + (uint32_t)ctidlen
+                         + (uint32_t)DLT_ID_SIZE;
+
+    msg.datasize = (int32_t)contextSize;
 
     if (msg.databuffer && (msg.databuffersize < msg.datasize)) {
         free(msg.databuffer);
@@ -2848,24 +2870,22 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
     if (msg.databuffer == 0)
         return -1;
 
-    resp.service_id = DLT_SERVICE_ID_UNREGISTER_CONTEXT;
-    resp.status = DLT_SERVICE_RESPONSE_OK;
-    dlt_set_id_v2(resp.apid, apid, resp.apidlen);
-    dlt_set_id_v2(resp.ctid, ctid, resp.ctidlen);
-    dlt_set_id(resp.comid, comid);
-
     memcpy(msg.databuffer + offset, &(resp.service_id), sizeof(uint32_t));
     offset = offset + (int)sizeof(uint32_t);
     memcpy(msg.databuffer + offset, &(resp.status), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
     memcpy(msg.databuffer + offset, &(resp.apidlen), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    memcpy(msg.databuffer + offset, resp.apid, resp.apidlen);
-    offset = offset + (int)resp.apidlen;
+    if ((resp.apidlen > 0) && (resp.apid != NULL)) {
+        memcpy(msg.databuffer + offset, resp.apid, resp.apidlen);
+        offset = offset + (int)resp.apidlen;
+    }
     memcpy(msg.databuffer + offset, &(resp.ctidlen), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    memcpy(msg.databuffer + offset, resp.ctid, resp.ctidlen);
-    offset = offset + (int)resp.ctidlen;
+    if ((resp.ctidlen > 0) && (resp.ctid != NULL)) {
+        memcpy(msg.databuffer + offset, resp.ctid, resp.ctidlen);
+        offset = offset + (int)resp.ctidlen;
+    }
     memcpy(msg.databuffer + offset, resp.comid, DLT_ID_SIZE);
 
     /* send message */

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2815,9 +2815,11 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
                                                   int verbose)
 {
     DltMessageV2 msg;
-    /* Zero-initialise the entire response struct so apidlen / ctidlen
-     * cannot leak uninitialised stack memory to the wire (see #867 / #866). */
+    /* Zero-initialise so apidlen/ctidlen never leak uninitialised stack
+     * memory to the wire (#867). */
     DltServiceUnregisterContextV2 resp = {0};
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     int offset = 0;
 
     PRINT_FUNCTION_VERBOSE(verbose);
@@ -2829,27 +2831,26 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
     if (dlt_message_init_v2(&msg, 0) == DLT_RETURN_ERROR)
         return -1;
 
-    /* Populate response fields from the function parameters. The
-     * DltServiceUnregisterContextV2 struct uses `char *` for apid / ctid;
-     * point them at the caller-supplied buffers (which outlive this call).
-     * Previously these fields were left NULL while dlt_set_id_v2() was
-     * called with the NULL destination, which is a no-op — the apid /
-     * ctid bytes were never copied into the response. resp.apidlen and
-     * resp.ctidlen were also never assigned, so the subsequent memcpy of
-     * &(resp.apidlen) / &(resp.ctidlen) wrote uninitialised stack memory
-     * to the wire. See #866 for context on the broader pattern. */
+    /* Build the response, copying the ids through the shared dlt_set_id_v2()
+     * helper into local buffers rather than assigning raw pointers. The
+     * struct's apid/ctid are char *, so the previous dlt_set_id_v2(resp.apid,
+     * ...) call ran against a NULL destination and never copied anything. */
     resp.service_id = DLT_SERVICE_ID_UNREGISTER_CONTEXT;
     resp.status     = DLT_SERVICE_RESPONSE_OK;
     resp.apidlen    = apidlen;
-    resp.apid       = apid;
     resp.ctidlen    = ctidlen;
-    resp.ctid       = ctid;
+    if (apidlen > 0) {
+        dlt_set_id_v2(apid_buf, apid, apidlen);
+        resp.apid = apid_buf;
+    }
+    if (ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, ctid, ctidlen);
+        resp.ctid = ctid_buf;
+    }
     dlt_set_id(resp.comid, comid);
 
-    /* prepare payload of data — use a wider type so the size calculation
-     * cannot overflow when apidlen + ctidlen approach their uint8_t maxima.
-     * Previously a (uint8_t) cast wrapped mod 256, underallocating
-     * msg.databuffer and corrupting the heap on the memcpy chain below. */
+    /* Wider type so the size sum cannot wrap mod 256 (a uint8_t cast here
+     * previously underallocated msg.databuffer and corrupted the heap). */
     uint32_t contextSize = (uint32_t)sizeof(uint32_t) + (uint32_t)sizeof(uint8_t)
                          + (uint32_t)sizeof(uint8_t) + (uint32_t)apidlen
                          + (uint32_t)sizeof(uint8_t) + (uint32_t)ctidlen


### PR DESCRIPTION
## Problem

`dlt_daemon_control_message_unregister_context_v2` had four
distinct bugs (full analysis in #867):

1. **Heap underallocation via `(uint8_t)` truncation** — the
   `contextSize` cast wrapped mod 256, undersizing `msg.datasize`
   for the subsequent `memcpy` chain.
2. **Uninitialised-stack disclosure to wire** — `resp.apidlen` and
   `resp.ctidlen` were never assigned, but were `memcpy`'d into the
   response, leaking two bytes of stack contents per unregister
   notification.
3. **`memcpy` from NULL with uninitialised length** — `resp.apid` /
   `resp.ctid` were set to NULL and the subsequent
   `dlt_set_id_v2(resp.apid, ...)` calls no-op'd; the variable-length
   `memcpy`s then ran with a NULL source and a random length.
4. **Wrong wire output** — the function's parameters were never
   copied into `resp`, so even when the daemon survived the call the
   notification carried garbage lengths and zero context bytes.

Reachable on every context unregistration (called from
`dlt-daemon.c:5001`).

## Fix

- Zero-initialise `resp` with `= {0}`.
- Explicitly assign `resp.apidlen` / `resp.apid` / `resp.ctidlen` /
  `resp.ctid` from the function parameters before serialisation.
- Replace the `(uint8_t) contextSize` cast with a `uint32_t`
  accumulator that matches the `int32_t` width of `msg.datasize`.
- Guard the variable-length `memcpy`s with `len > 0 && ptr != NULL`
  so a future caller passing NULL for an empty field can't UB.

## Notes

- This is one of the four V2 control-handler bugs called out in the
  meta-Issue #866. Follow-up PRs for the others
  (`set_trace_status_v2`, `get_log_info_v2` parsing, possibly more)
  will reference #866 too.
- Tested by reading the diff and walking the new control flow; have
  not added a regression test because this code path is exercised
  only end-to-end with a live daemon and a disconnecting application.
  Happy to add one if maintainers can point me at the right harness.

Closes #867.
Related: #866.