### PR TITLE
fix(logstorage): replace unbounded strcat with snprintf in storage_dir_info

### DIFF
--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -430,11 +430,10 @@ int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
 
             char tmpfile[DLT_OFFLINE_LOGSTORAGE_MAX_LOG_FILE_LEN + 1] = { '\0' };
             if (dir != NULL) {
-                /* Append directory path */
-                strcat(tmpfile, dir);
-                strcat(tmpfile, "/");
+                snprintf(tmpfile, sizeof(tmpfile), "%s/%s", dir, files[i]->d_name);
+            } else {
+                strncpy(tmpfile, files[i]->d_name, DLT_OFFLINE_LOGSTORAGE_MAX_LOG_FILE_LEN);
             }
-            strcat(tmpfile, files[i]->d_name);
             (*tmp)->name = strdup(tmpfile);
             (*tmp)->idx = current_idx;
             (*tmp)->next = NULL;


### PR DESCRIPTION
## Summary

`dlt_logstorage_storage_dir_info()` in `dlt_offline_logstorage_behavior.c` builds a file path from three pieces using three chained `strcat()` calls into a fixed-size stack buffer:

```c
char tmpfile[DLT_OFFLINE_LOGSTORAGE_MAX_LOG_FILE_LEN + 1] = { '\0' };  // 121 bytes
if (dir != NULL) {
    strcat(tmpfile, dir);          // up to ~99 chars (from config)
    strcat(tmpfile, "/");          // + 1
}
strcat(tmpfile, files[i]->d_name); // up to NAME_MAX = 255 chars
```

`dir` is derived from a config-bounded field (max `DLT_OFFLINE_LOGSTORAGE_MAX_FILE_NAME_LEN` = 100 chars), so the directory component is bounded. However `files[i]->d_name` comes from `scandir()` and can be up to `NAME_MAX` (255 bytes) on Linux.

`dir(~99) + "/" + d_name(~255) = ~355 bytes` can easily overflow the 121-byte `tmpfile` buffer, causing a stack buffer overflow. The overflow is triggerable whenever the storage directory contains a file whose name exceeds the buffer capacity, which can happen naturally or via a crafted mount-point with long filenames.

## Changes

Replace the three `strcat()` calls with a single `snprintf(..., sizeof(tmpfile), ...)`, which hard-limits the write to the buffer size. Add a `strncpy` for the no-directory branch for consistency.

## Testing

- Paths shorter than `DLT_OFFLINE_LOGSTORAGE_MAX_LOG_FILE_LEN` are copied unchanged.
- Paths longer than the buffer are safely truncated; no stack overflow.