### PR TITLE
fix: restore description_length cap in V2 register_application and register_context

### DIFF
--- a/src/daemon/dlt-daemon.c
+++ b/src/daemon/dlt-daemon.c
@@ -4009,10 +4009,10 @@ int dlt_daemon_process_user_message_register_application(DltDaemon *daemon,
 
         len = usercontext.description_length;
 
-        // if (len > DLT_DAEMON_DESCSIZE) {
-        //     len = DLT_DAEMON_DESCSIZE;
-        //     dlt_log(LOG_WARNING, "Application description exceeds limit\n");
-        // }
+        if (len > DLT_DAEMON_DESCSIZE) {
+            len = DLT_DAEMON_DESCSIZE;
+            dlt_log(LOG_WARNING, "Application description exceeds limit\n");
+        }
 
         /* adjust buffer pointer */
         rec->buf += to_remove + sizeof(DltUserHeader);
@@ -4298,10 +4298,10 @@ int dlt_daemon_process_user_message_register_context(DltDaemon *daemon,
 
         len = usercontext.description_length;
 
-        // if (len > DLT_DAEMON_DESCSIZE) {
-        //     dlt_vlog(LOG_WARNING, "Context description exceeds limit: %u\n", len);
-        //     len = DLT_DAEMON_DESCSIZE;
-        // }
+        if (len > DLT_DAEMON_DESCSIZE) {
+            dlt_vlog(LOG_WARNING, "Context description exceeds limit: %u\n", len);
+            len = DLT_DAEMON_DESCSIZE;
+        }
 
         /* adjust buffer pointer */
         rec->buf += to_remove + sizeof(DltUserHeader);


### PR DESCRIPTION
## Summary

Uncomment the `description_length` sanity guards in the two DLTv2 IPC registration
handlers that were accidentally left commented out during the V2 upgrade series.

Without these guards, an attacker-controlled `description_length` (uint32) is passed
directly to `dlt_receiver_check_and_get`, which calls `memcpy` into a 257-byte stack
buffer (`description[DLT_DAEMON_DESCSIZE + 1]`), causing a stack buffer overflow.

The equivalent V1 code paths at lines ~4116 and ~4540 apply the cap correctly.

## Changes

- `dlt_daemon_process_user_message_register_application` (V2 branch, line ~4012):
  Uncomment `if (len > DLT_DAEMON_DESCSIZE)` guard
- `dlt_daemon_process_user_message_register_context` (V2 branch, line ~4301):
  Uncomment `if (len > DLT_DAEMON_DESCSIZE)` guard

## Testing

- ASAN build: stack-buffer-overflow crash eliminated on both sites
- Daemon operates normally with warning logged for oversized descriptions
- V1 code paths unaffected (they already have the guard active)

Closes #875