### PR TITLE
bump cmake version to minimum 3.16.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
-cmake_minimum_required(VERSION 3.13...4.0)
+cmake_minimum_required(VERSION 3.16.5)
 project(automotive-dlt VERSION 3.0.1)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
+cmake_minimum_required(VERSION 3.10.2)
 project(automotive-dlt VERSION 3.0.1)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@
 #######
 
 # Set minimum Cmake version and setup policy behavior
-cmake_minimum_required(VERSION 3.16.5)
 project(automotive-dlt VERSION 3.0.1)
 
 


### PR DESCRIPTION
bump cmake version to minimum 3.16.5

- jobs are failing due to older version of cmake