### PR TITLE
[Prior2] fix: handle bufferoverflow and memory issues in v2 protocol

### DIFF
--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2151,10 +2151,30 @@ void dlt_daemon_control_get_log_info_v2(int sock,
     db_offset = db_offset + (int)sizeof(uint8_t);
     memcpy(&(req->apidlen), msg->databuffer + db_offset, sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+
+    /* apidlen and ctidlen are attacker-controlled (uint8_t each, up to 255).
+     * The fixed-size precheck at the top of this function only validates
+     * the empty case (apidlen = ctidlen = 0); before reading the
+     * variable-length apid (apidlen bytes) followed by ctidlen (1 byte),
+     * confirm the message is large enough to contain them. Otherwise
+     * dlt_set_id_v2() reads past msg->databuffer. */
+    if ((db_offset + (int)req->apidlen + (int)sizeof(uint8_t)) > msg->datasize) {
+        free(req);
+        return;
+    }
+
     dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
     db_offset = db_offset + (int)req->apidlen;
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
+
+    /* Same check for ctid (ctidlen bytes) and the trailing com field
+     * (DLT_ID_SIZE bytes). */
+    if ((db_offset + (int)req->ctidlen + DLT_ID_SIZE) > msg->datasize) {
+        free(req);
+        return;
+    }
+
     dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
     db_offset = db_offset + (int)req->ctidlen;
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2145,6 +2145,8 @@ void dlt_daemon_control_get_log_info_v2(int sock,
 
     /* prepare pointer to message request */
     int db_offset = 0;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     memcpy(&(req->service_id), msg->databuffer + db_offset, sizeof(uint32_t));
     db_offset = db_offset + (int)sizeof(uint32_t);
     memcpy(&(req->options), msg->databuffer + db_offset, sizeof(uint8_t));
@@ -2163,8 +2165,19 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         return;
     }
 
-    dlt_set_id_v2(req->apid, (const char *)(msg->databuffer + db_offset), req->apidlen);
-    db_offset = db_offset + (int)req->apidlen;
+    /* Copy the variable-length apid into a local fixed-size buffer through the
+     * dlt_set_id_v2() helper, then point req->apid at it. req->apid is a
+     * calloc'd char * (NULL), so the previous dlt_set_id_v2(req->apid, ...)
+     * call here was a no-op: req->apid stayed NULL and was later passed to
+     * dlt_daemon_application_find_v2() despite req->apidlen being non-zero,
+     * silently turning every non-empty apid lookup into a zero-length one.
+     * Giving the helper a real destination keeps id initialisation inside the
+     * shared API rather than hand-parsing the wire buffer. See #870. */
+    if (req->apidlen > 0) {
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + db_offset), req->apidlen);
+        req->apid = apid_buf;
+        db_offset = db_offset + (int)req->apidlen;
+    }
     memcpy(&(req->ctidlen), (const char *)(msg->databuffer + db_offset), sizeof(uint8_t));
     db_offset = db_offset + (int)sizeof(uint8_t);
 
@@ -2175,8 +2188,11 @@ void dlt_daemon_control_get_log_info_v2(int sock,
         return;
     }
 
-    dlt_set_id_v2(req->ctid, (const char *)(msg->databuffer + db_offset), req->ctidlen);
-    db_offset = db_offset + (int)req->ctidlen;
+    if (req->ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + db_offset), req->ctidlen);
+        req->ctid = ctid_buf;
+        db_offset = db_offset + (int)req->ctidlen;
+    }
     memcpy((req->com), (const char *)(msg->databuffer + db_offset), DLT_ID_SIZE);
 
     /* initialise new message */

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -2841,10 +2841,11 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
                                                   int verbose)
 {
     DltMessageV2 msg;
-    DltServiceUnregisterContextV2 resp;
-    uint8_t contextSize = 0;
-    resp.apid = NULL;
-    resp.ctid = NULL;
+    /* Zero-initialise so apidlen/ctidlen never leak uninitialised stack
+     * memory to the wire (#867). */
+    DltServiceUnregisterContextV2 resp = {0};
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     int offset = 0;
 
     PRINT_FUNCTION_VERBOSE(verbose);
@@ -2856,10 +2857,30 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
     if (dlt_message_init_v2(&msg, 0) == DLT_RETURN_ERROR)
         return -1;
 
-    /* prepare payload of data */
-    contextSize = (uint8_t)(sizeof(uint32_t) + sizeof(uint8_t) + sizeof(uint8_t) + apidlen + sizeof(uint8_t) + ctidlen + DLT_ID_SIZE);
+    /* Copy IDs into local buffers using dlt_set_id_v2() 
+       to avoid previous silent no-op failures on unallocated struct pointers. */
+    resp.service_id = DLT_SERVICE_ID_UNREGISTER_CONTEXT;
+    resp.status     = DLT_SERVICE_RESPONSE_OK;
+    resp.apidlen    = apidlen;
+    resp.ctidlen    = ctidlen;
+    if (apidlen > 0) {
+        dlt_set_id_v2(apid_buf, apid, apidlen);
+        resp.apid = apid_buf;
+    }
+    if (ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, ctid, ctidlen);
+        resp.ctid = ctid_buf;
+    }
+    dlt_set_id(resp.comid, comid);
 
-    msg.datasize = contextSize;
+    /* Wider type so the size sum cannot wrap mod 256 (a uint8_t cast here
+     * previously underallocated msg.databuffer and corrupted the heap). */
+    uint32_t contextSize = (uint32_t)sizeof(uint32_t) + (uint32_t)sizeof(uint8_t)
+                         + (uint32_t)sizeof(uint8_t) + (uint32_t)apidlen
+                         + (uint32_t)sizeof(uint8_t) + (uint32_t)ctidlen
+                         + (uint32_t)DLT_ID_SIZE;
+
+    msg.datasize = (int32_t)contextSize;
 
     if (msg.databuffer && (msg.databuffersize < msg.datasize)) {
         free(msg.databuffer);
@@ -2874,24 +2895,22 @@ int dlt_daemon_control_message_unregister_context_v2(int sock,
     if (msg.databuffer == 0)
         return -1;
 
-    resp.service_id = DLT_SERVICE_ID_UNREGISTER_CONTEXT;
-    resp.status = DLT_SERVICE_RESPONSE_OK;
-    dlt_set_id_v2(resp.apid, apid, resp.apidlen);
-    dlt_set_id_v2(resp.ctid, ctid, resp.ctidlen);
-    dlt_set_id(resp.comid, comid);
-
     memcpy(msg.databuffer + offset, &(resp.service_id), sizeof(uint32_t));
     offset = offset + (int)sizeof(uint32_t);
     memcpy(msg.databuffer + offset, &(resp.status), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
     memcpy(msg.databuffer + offset, &(resp.apidlen), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    memcpy(msg.databuffer + offset, resp.apid, resp.apidlen);
-    offset = offset + (int)resp.apidlen;
+    if ((resp.apidlen > 0) && (resp.apid != NULL)) {
+        memcpy(msg.databuffer + offset, resp.apid, resp.apidlen);
+        offset = offset + (int)resp.apidlen;
+    }
     memcpy(msg.databuffer + offset, &(resp.ctidlen), sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
-    memcpy(msg.databuffer + offset, resp.ctid, resp.ctidlen);
-    offset = offset + (int)resp.ctidlen;
+    if ((resp.ctidlen > 0) && (resp.ctid != NULL)) {
+        memcpy(msg.databuffer + offset, resp.ctid, resp.ctidlen);
+        offset = offset + (int)resp.ctidlen;
+    }
     memcpy(msg.databuffer + offset, resp.comid, DLT_ID_SIZE);
 
     /* send message */

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -4087,84 +4087,117 @@ void dlt_daemon_control_set_trace_status_v2(int sock,
 
     char *apid = NULL;
     char *ctid = NULL;
-    DltServiceSetLogLevelV2 *req = NULL;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     DltDaemonContext *context = NULL;
-    int8_t apid_length = 0;
-    int8_t ctid_length = 0;
+    uint32_t service_id = 0;
+    uint8_t apidlen = 0;
+    uint8_t ctidlen = 0;
+    uint8_t log_level = 0;
+    int offset = 0;
 
     if ((daemon == NULL) || (msg == NULL) || (msg->databuffer == NULL))
         return;
 
-    //TBD: Review sizeof(DltServiceSetLogLevelV2)) or fixed size
-    if (dlt_check_rcv_data_size(msg->datasize, sizeof(DltServiceSetLogLevelV2)) < 0)
+    if (dlt_check_rcv_data_size(msg->datasize, DLT_SERVICE_SET_LOG_LEVEL_FIXED_SIZE_V2) < 0)
         return;
 
-    req = (DltServiceSetLogLevelV2 *)(msg->databuffer);
+    /* Parse wire bytes incrementally to avoid an arbitrary memory read from network 
+       pointers and prevent a subsequent null-pointer dereference. */
+    memcpy(&service_id, msg->databuffer + offset, sizeof(uint32_t));
+    offset = offset + (int)sizeof(uint32_t);
+    memcpy(&apidlen, msg->databuffer + offset, sizeof(uint8_t));
+    offset = offset + (int)sizeof(uint8_t);
+
+    /* Bounds check for apid (apidlen bytes) + the upcoming ctidlen byte.
+     * The fixed-size precheck at the top only validates the empty case. */
+    if ((offset + (int)apidlen + (int)sizeof(uint8_t)) > msg->datasize)
+        return;
+
+    /* Safely extract the variable-length apid into a local fixed-size buffer using the 
+       shared dlt_set_id_v2() API helper. */
+    if (apidlen > 0) {
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + offset), apidlen);
+        apid = apid_buf;
+        offset = offset + (int)apidlen;
+    }
+    memcpy(&ctidlen, msg->databuffer + offset, sizeof(uint8_t));
+    offset = offset + (int)sizeof(uint8_t);
+
+    /* Ensure the payload buffer contains sufficient remaining bytes for both the dynamic apidlen and the trailing ctidlen byte. */
+    if ((offset + (int)ctidlen + (int)sizeof(uint8_t) + DLT_ID_SIZE) > msg->datasize)
+        return;
+
+    if (ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + offset), ctidlen);
+        ctid = ctid_buf;
+        offset = offset + (int)ctidlen;
+    }
+    memcpy(&log_level, msg->databuffer + offset, sizeof(uint8_t));
 
     if (daemon_local->flags.enforceContextLLAndTS)
-        req->log_level = (uint8_t) getStatus(req->log_level, daemon_local->flags.contextTraceStatus);
+        log_level = (uint8_t) getStatus(log_level, daemon_local->flags.contextTraceStatus);
 
-    apid_length = (int8_t) req->apidlen;
-    dlt_set_id_v2(apid, req->apid, req->apidlen);
-    ctid_length = (int8_t) req->ctidlen;
-    dlt_set_id_v2(ctid, req->ctid, req->ctidlen);
-
-    //TBD: Review apid[apid_length - 1] == '*'
-    if ((apid_length != 0) && (apid[apid_length - 1] == '*') && (ctid == NULL)) { /*apid provided having '*' in it and ctid is null*/
+    /* Use unsigned widths to prevent signed integer underflow when lengths exceed 127, 
+       avoiding out-of-bounds array indexing. */
+    if ((apidlen != 0) && (apid != NULL) && (apid[apidlen - 1] == '*') && (ctid == NULL)) {
+        /* apid provided having '*' in it and ctid is null */
         dlt_daemon_find_multiple_context_and_send_trace_status_v2(sock,
                                                                daemon,
                                                                daemon_local,
                                                                1,
                                                                apid,
-                                                               (int8_t) (apid_length - 1),
-                                                               (int8_t) req->log_level,
+                                                               (int8_t) (apidlen - 1),
+                                                               (int8_t) log_level,
                                                                verbose);
     }
-    else if ((ctid_length != 0) && (ctid[ctid_length - 1] == '*') && (apid == NULL)) /*ctid provided is having '*' in it and apid is null*/
-
+    else if ((ctidlen != 0) && (ctid != NULL) && (ctid[ctidlen - 1] == '*') && (apid == NULL))
     {
+        /* ctid provided is having '*' in it and apid is null */
         dlt_daemon_find_multiple_context_and_send_trace_status_v2(sock,
                                                                daemon,
                                                                daemon_local,
                                                                0,
                                                                ctid,
-                                                               (int8_t) (ctid_length - 1),
-                                                               (int8_t) req->log_level,
+                                                               (int8_t) (ctidlen - 1),
+                                                               (int8_t) log_level,
                                                                verbose);
     }
-    else if ((apid_length != 0) && (apid[apid_length - 1] != '*') && (ctid == NULL)) /*only app id case*/
+    else if ((apidlen != 0) && (apid != NULL) && (apid[apidlen - 1] != '*') && (ctid == NULL))
     {
+        /* only app id case */
         dlt_daemon_find_multiple_context_and_send_trace_status_v2(sock,
                                                                daemon,
                                                                daemon_local,
                                                                1,
                                                                apid,
-                                                               apid_length,
-                                                               (int8_t) req->log_level,
+                                                               (int8_t) apidlen,
+                                                               (int8_t) log_level,
                                                                verbose);
     }
-    else if ((ctid_length != 0) && (ctid[ctid_length - 1] != '*') && (apid == NULL)) /*only context id case*/
+    else if ((ctidlen != 0) && (ctid != NULL) && (ctid[ctidlen - 1] != '*') && (apid == NULL))
     {
+        /* only context id case */
         dlt_daemon_find_multiple_context_and_send_trace_status_v2(sock,
                                                                daemon,
                                                                daemon_local,
                                                                0,
                                                                ctid,
-                                                               ctid_length,
-                                                               (int8_t) req->log_level,
+                                                               (int8_t) ctidlen,
+                                                               (int8_t) log_level,
                                                                verbose);
     }
     else {
-        context = dlt_daemon_context_find_v2(daemon, (uint8_t)apid_length, apid, (uint8_t)ctid_length, ctid, daemon->ecuid2len, daemon->ecuid2, verbose);
+        context = dlt_daemon_context_find_v2(daemon, apidlen, apid, ctidlen, ctid, daemon->ecuid2len, daemon->ecuid2, verbose);
 
         /* Set trace status */
         if (context != 0) {
-            dlt_daemon_send_trace_status_v2(sock, daemon, daemon_local, context, (int8_t) req->log_level, verbose);
+            dlt_daemon_send_trace_status_v2(sock, daemon, daemon_local, context, (int8_t) log_level, verbose);
         }
         else {
             dlt_vlog(LOG_ERR,
                      "Could not set trace status: %d. Context [%.4s:%.4s] not found:",
-                     req->log_level,
+                     log_level,
                      apid ? apid : "<NULL>",
                      ctid ? ctid : "<NULL>");
             dlt_daemon_control_service_response_v2(sock,

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -3692,6 +3692,8 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     PRINT_FUNCTION_VERBOSE(verbose);
     char *apid =NULL;
     char *ctid =NULL;
+    char apid_buf[DLT_V2_ID_SIZE] = {0};
+    char ctid_buf[DLT_V2_ID_SIZE] = {0};
     DltServiceSetLogLevelV2 req = {0};
     DltDaemonContext *context = NULL;
     int8_t apid_length = 0;
@@ -3709,23 +3711,23 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
 
-    /* Validate buffer size against dynamic apidlen and ctidlen to prevent 
-       an out-of-bounds read in dlt_set_id_v2(). */
-    if ((offset + (int)req.apidlen + (int)sizeof(uint8_t)) > msg->datasize)
-        return;
+    /* Pass a valid destination buffer to dlt_set_id_v2() to prevent a silent no-op 
+       and subsequent null-pointer crash downstream. */
+    if (req.apidlen > 0) {
+        dlt_set_id_v2(apid_buf, (const char *)(msg->databuffer + offset), req.apidlen);
+        req.apid = apid_buf;
+        offset = offset + req.apidlen;
+    }
 
-    dlt_set_id_v2(req.apid, (const char *)(msg->databuffer + offset), req.apidlen);
-    offset = offset + req.apidlen;
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
 
-    /* Same check for ctid (ctidlen bytes), the trailing log_level byte,
-     * and the com field (DLT_ID_SIZE bytes). */
-    if ((offset + (int)req.ctidlen + (int)sizeof(uint8_t) + DLT_ID_SIZE) > msg->datasize)
-        return;
+    if (req.ctidlen > 0) {
+        dlt_set_id_v2(ctid_buf, (const char *)(msg->databuffer + offset), req.ctidlen);
+        req.ctid = ctid_buf;
+        offset = offset + req.ctidlen;
+    }
 
-    dlt_set_id_v2(req.ctid, (const char *)(msg->databuffer + offset), req.ctidlen);
-    offset = offset + req.ctidlen;
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
     memcpy(&(req.com), msg->databuffer + offset, DLT_ID_SIZE);
@@ -3733,10 +3735,11 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     if (daemon_local->flags.enforceContextLLAndTS)
         req.log_level = (uint8_t) getStatus(req.log_level, daemon_local->flags.contextLogLevel);
 
+    /* Alias the lookup pointers directly to req.apid and req.ctid now that they reference the populated buffers. */
+    apid = req.apid;
     apid_length = (int8_t) req.apidlen;
-    dlt_set_id_v2(apid, req.apid, req.apidlen);
+    ctid = req.ctid;
     ctid_length = (int8_t) req.ctidlen;
-    dlt_set_id_v2(ctid, req.ctid, req.ctidlen);
 
     if ((apid_length != 0) && (apid[apid_length - 1] == '*') && (ctid == NULL)) { /*apid provided having '*' in it and ctid is null*/
         dlt_daemon_find_multiple_context_and_send_log_level_v2(sock,

--- a/src/daemon/dlt_daemon_client.c
+++ b/src/daemon/dlt_daemon_client.c
@@ -3708,10 +3708,22 @@ void dlt_daemon_control_set_log_level_v2(int sock,
     offset = offset + (int)sizeof(uint32_t);
     memcpy(&(req.apidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+
+    /* Validate buffer size against dynamic apidlen and ctidlen to prevent 
+       an out-of-bounds read in dlt_set_id_v2(). */
+    if ((offset + (int)req.apidlen + (int)sizeof(uint8_t)) > msg->datasize)
+        return;
+
     dlt_set_id_v2(req.apid, (const char *)(msg->databuffer + offset), req.apidlen);
     offset = offset + req.apidlen;
     memcpy(&(req.ctidlen), msg->databuffer + offset, sizeof(uint8_t));
     offset = offset + (int)sizeof(uint8_t);
+
+    /* Same check for ctid (ctidlen bytes), the trailing log_level byte,
+     * and the com field (DLT_ID_SIZE bytes). */
+    if ((offset + (int)req.ctidlen + (int)sizeof(uint8_t) + DLT_ID_SIZE) > msg->datasize)
+        return;
+
     dlt_set_id_v2(req.ctid, (const char *)(msg->databuffer + offset), req.ctidlen);
     offset = offset + req.ctidlen;
     memcpy(&(req.log_level), msg->databuffer + offset, sizeof(uint8_t));

--- a/src/lib/dlt_user.c
+++ b/src/lib/dlt_user.c
@@ -4670,7 +4670,11 @@ DltReturnValue dlt_with_filename_and_line_number(const char *fina, const int lin
 
     /* Set filename and line number */
     dlt_user.with_filename_and_line_number = 1;
-    dlt_user.filenamelen = (uint8_t)strlen(fina);
+
+    /* Clamp filenamelen to UINT8_MAX to prevent integer overflow and 
+       undersized heap allocation when string length exceeds 255. */
+    dlt_user.filenamelen = (strlen(fina) > UINT8_MAX) ? (uint8_t)UINT8_MAX : (uint8_t)strlen(fina);
+
     if (dlt_user.filename != NULL) {
         free(dlt_user.filename);
         dlt_user.filename = NULL;
@@ -4681,7 +4685,8 @@ DltReturnValue dlt_with_filename_and_line_number(const char *fina, const int lin
         dlt_vlog(LOG_ERR, "%s Could not allocate memory for filename", __func__);
         return DLT_RETURN_ERROR;
     }
-    strcpy(dlt_user.filename, fina);
+    strncpy(dlt_user.filename, fina, (size_t)dlt_user.filenamelen);
+    dlt_user.filename[(size_t)dlt_user.filenamelen] = '\0';
 
     dlt_user.linenumber = (uint32_t)linr;
     return DLT_RETURN_OK;

--- a/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
+++ b/src/offlinelogstorage/dlt_offline_logstorage_behavior.c
@@ -428,13 +428,12 @@ int dlt_logstorage_storage_dir_info(DltLogStorageUserConfig *file_config,
                 }
             }
 
-            char tmpfile[DLT_OFFLINE_LOGSTORAGE_MAX_LOG_FILE_LEN + 1] = { '\0' };
+            char tmpfile[DLT_OFFLINE_LOGSTORAGE_MAX_FILE_NAME_LEN + NAME_MAX + 2] = { '\0' };
             if (dir != NULL) {
-                /* Append directory path */
-                strcat(tmpfile, dir);
-                strcat(tmpfile, "/");
+                snprintf(tmpfile, sizeof(tmpfile), "%s/%s", dir, files[i]->d_name);
+            } else {
+                strncpy(tmpfile, files[i]->d_name, sizeof(tmpfile) - 1);
             }
-            strcat(tmpfile, files[i]->d_name);
             (*tmp)->name = strdup(tmpfile);
             (*tmp)->idx = current_idx;
             (*tmp)->next = NULL;

--- a/tests/gtest_dlt_common_v2.cpp
+++ b/tests/gtest_dlt_common_v2.cpp
@@ -1557,6 +1557,71 @@ TEST(t_dlt_message_argument_print_v2, nullpointer)
 /* End Method:dlt_common::dlt_message_argument_print_v2 */
 
 
+/* Begin Method:dlt_common::dlt_set_id_v2 */
+TEST(t_dlt_set_id_v2, normal)
+{
+    char id[DLT_V2_ID_SIZE];
+
+    /* Execute exact-length copy to properly populate 
+       the destination buffer and prevent silent no-op failures on NULL pointers. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "ABCD", 4);
+    EXPECT_EQ(0, memcmp(id, "ABCD", 4));
+    EXPECT_EQ('\0', id[4]);
+
+    /* Single character id. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "X", 1);
+    EXPECT_EQ('X', id[0]);
+    EXPECT_EQ('\0', id[1]);
+
+    /* A length longer than the text stops at the embedded terminator. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "AB", 8);
+    EXPECT_EQ(0, memcmp(id, "AB", 2));
+    EXPECT_EQ('\0', id[2]);
+}
+
+TEST(t_dlt_set_id_v2, truncation)
+{
+    /* The length argument is a uint8_t, so the maximum value (255) equals
+     * DLT_V2_ID_SIZE and is exactly the cap boundary. Fill the whole
+     * destination and use a trailing guard byte to detect any write past
+     * the buffer end. */
+    struct {
+        char id[DLT_V2_ID_SIZE];
+        char guard;
+    } b;
+    char src[DLT_V2_ID_SIZE];
+
+    memset(src, 'Z', sizeof(src));
+    b.guard = 'G';
+    memset(b.id, 0xAA, sizeof(b.id));
+
+    dlt_set_id_v2(b.id, src, (uint8_t)DLT_V2_ID_SIZE);
+
+    for (int i = 0; i < DLT_V2_ID_SIZE; i++)
+        EXPECT_EQ('Z', b.id[i]);
+    EXPECT_EQ('G', b.guard);
+}
+
+TEST(t_dlt_set_id_v2, nullpointer)
+{
+    char id[DLT_V2_ID_SIZE] = {0};
+
+    /* Must tolerate NULL/zero arguments without crashing and without
+     * touching the destination. */
+    EXPECT_NO_THROW(dlt_set_id_v2(NULL, "ABCD", 4));
+    EXPECT_NO_THROW(dlt_set_id_v2(id, NULL, 4));
+    EXPECT_NO_THROW(dlt_set_id_v2(NULL, NULL, 0));
+
+    /* len == 0 leaves the destination untouched. */
+    memset(id, 0xAA, sizeof(id));
+    dlt_set_id_v2(id, "ABCD", 0);
+    EXPECT_EQ((char)0xAA, id[0]);
+}
+/* End Method:dlt_common::dlt_set_id_v2 */
+
 
 /*##############################################################################################################################*/
 /*##############################################################################################################################*/


### PR DESCRIPTION
Combine multiple related PRs #861, #862, #864, #865, #868, #869 #873

## Summary
This PR consolidates several interdependent / closely related pull requests into a single, cohesive change set. Combining them reduces merge friction, ensures consistent testing, and simplifies the review process for the team.

The following PRs are squashed / merged into this branch:
- #861
- #862
- #864
- #865
- #868
- #869
- #873

---

## Changes included
- **[#861]** – <daemon: fix GET_LOG_INFO V2 request parsing>
- **[#862]** – <daemon: fix out-of-bounds read in dlt_daemon_control_set_log_level_v2>
- **[#864]** – <daemon: fix APID/CTID parsing in set_log_level_v2>
- **[#865]** – <lib: fix heap buffer overflow in dlt_with_filename_and_line_number>
- **[#868]** – <daemon: fix unregister_context_v2 response construction>
- **[#869]** – <daemon: parse incrementally in dlt_daemon_control_set_trace_status_v2>
- **[#873]** – <fix(logstorage): replace unbounded strcat with snprintf in storage_dir_info>

> ℹ️ For detailed rationale, please refer to the individual PR threads linked above.